### PR TITLE
Propose Arbitrary Meeting Time

### DIFF
--- a/irc-meetings.md
+++ b/irc-meetings.md
@@ -8,7 +8,7 @@ This RFC declares what community meetings we hold and how we hold them.
 
 ### Time
 
-Every two weeks on Friday, at 9am Pacific. 1 hour.
+Every two weeks on Friday, at 1200 Pacific Time Zone, respecting local Daylight Savings practices. 1 hour.
 
 ### Location
 


### PR DESCRIPTION
- The 9am meeting time is 4am New Zealand time
- It may be exclusionary to other time zones
- This part of the year is the worst for Time Zone overlap for myself
  and PTZ specifically (dual DST offsets)
- I have no data to back up this meeting time
- I would like to see more folks in diverse time zones able to attend
