### PR TITLE
Arbitrary cookbook identifiers

### DIFF
--- a/arbitrary-cookbook-identifiers.md
+++ b/arbitrary-cookbook-identifiers.md
@@ -74,6 +74,12 @@ look like:
 uploaded cookbook to allow full SemVer version numbers. This allows
 users to add extra information to the version field if they choose to do
 so.
+* If feasible, the `cookbook_artifacts` endpoint should provide a bulk
+API that allows an API consumer to request multiple cookbook objects
+in a single request response cycle. The existing server-side dependency
+solver endpoint at `/environments/:environment/cookbook_versions`
+provides this behavior, but is not be used by chef-client when
+fetching cookbooks via the new artifact-based API.
 
 ### How Chef Client Uses Cookbooks with Arbitrary IDs
 


### PR DESCRIPTION
This proposal describes an enhancement to chef server that allows uploads of cookbooks that are identified by arbitrary IDs. This feature supports the ChefDK policyfile feature, where we intend to identify cookbooks by a SHA-1 hash of the content. This allows users to safely publish cookbook changes without updating the cookbook's version number if they choose to do so (some reasons why users might want to do this are enumerated in the proposal). In ChefDK we also intend to expose functionality that allows the user to set the identifier of a cookbook to an arbitrary string (see the proposal for some caveats about the "arbitrary-ness").

Note that nothing in this proposal prevents a user from carefully managing the versions of their cookbooks if they feel that it is valuable. Furthermore, it is recommended that this API be a bit more verbose than the current API so that users have enough information to manage cookbooks with identifiers that are lacking in semantic meaning.

Finally, pretty much the entire design is up for discussion. The design I have proposed has some outcomes that I believe are worthwhile, but there are just a few hard constraints so any design that satisfies those constraints is acceptable.
