### PR TITLE
Chef 12 scoping and Supported Versions of Chef

### DIFF
--- a/chef-12.md
+++ b/chef-12.md
@@ -35,7 +35,7 @@ At a given time:
 
 ### Operating System Versions
 
-This topic deserves an RFC of its own. Our own Julian Dunn is working on one [here](https://github.com/opscode/chef-rfc/pull/21) in parallel.
+Supported Operating Systems and versions are covered by a separate [proposed RFC](https://github.com/opscode/chef-rfc/pull/21).
 
 ## Chef 12
 


### PR DESCRIPTION
This RFC codifies our policy as a community for the supported versions of Chef and supported versions of Ruby for Chef. 

In the light of this policy it also contains a scoping exercise for Chef 12.
