### PR TITLE
RFC000: Updating RFCs

### DIFF
--- a/rfc000-rfc-process.md
+++ b/rfc000-rfc-process.md
@@ -116,6 +116,18 @@ the original one should be marked as Replaced.
 * **Final** – The RFC has been implemented. *(Standards Track type only)*
 * **Replaced** – The RFC has been superseded by another RFC.
 
+### Changing an Accepted RFC
+
+An accepted RFC may be modified in two ways, depending on the type of RFC:
+
+1) To support software implementations meeting the specifications of an RFC,
+Standards Track RFCs must be replaced by a new RFC. This is done by specifying
+the RFC that is being replaced using the Replaces header in the metadata of the
+new RFC.
+
+To simplify their evolution, existing Informational and Process RFCs may also
+be updated by pull request.
+
 ## RFC Template
 
 ```markdown
@@ -124,6 +136,7 @@ RFC: unassigned
 Author: Alan Smithee <asmithee@example.com>
 Status: Draft
 Type: <Standards Track, Informational, Process>
+<Replaces: RFCxxx>
 ---
 
 # Title

--- a/rfc000-rfc-process.md
+++ b/rfc000-rfc-process.md
@@ -120,13 +120,15 @@ the original one should be marked as Replaced.
 
 An accepted RFC may be modified in two ways, depending on the type of RFC:
 
-1) To support software implementations meeting the specifications of an RFC,
-Standards Track RFCs must be replaced by a new RFC. This is done by specifying
-the RFC that is being replaced using the Replaces header in the metadata of the
-new RFC.
+1) Most RFCs can be updated by opening a pull request against them with the
+proposed changes. Once the changes are approved by the Decider, the pull
+request is merged and considered Accepted.
 
-To simplify their evolution, existing Informational and Process RFCs may also
-be updated by pull request.
+2) To support software implementations meeting the specifications of an RFC,
+Standards Track RFCs that are Final must be replaced by a new RFC. The Author
+should specify the RFC that is being replaced using the Replaces header in the
+metadata of the new RFC. Once Accepted, the replaced RFC with have its status
+updated to Replaced by an Editor.
 
 ## RFC Template
 


### PR DESCRIPTION
Specify that 'Standards Track' RFCs require a new RFC to change, while
Informational and Process RFCs may be updated by pull request.