### PR TITLE
Update the maintenance policy to accelerate code review and merge

### DIFF
--- a/rfc030-maintenance-policy.md
+++ b/rfc030-maintenance-policy.md
@@ -1,6 +1,6 @@
 ---
 RFC: 30
-Author: Adam Jacob <adam@getchef.com>
+Author: Adam Jacob <adam@chef.io>
 Status: Accepted
 Type: Process
 ---
@@ -29,96 +29,98 @@ This file is the canonical source for how the Chef project is maintained.
 * Provides vision and roadmap
 * Has universal veto power
 
-## Lieutenants
+## Lieutenant
 
-* Publish a roadmap (two quarters out)
-* Release calendar for code outside of chef client/chef server
-* Resolves disputes within their subsystem
+* Publishes a roadmap (two quarters out)
+* Provides a release calendar for code outside of chef client/chef server
+* Resolves disputes within their component
 * Has localized veto power
-* Plus all responsibilities of a maintainer
+* Plus all the responsibilities of a Maintainer
 
 ## Maintainer
 
-* Handle contributions on GitHub - first response to a PR within 48 hours
-* Be available on IRC
-* Attend the developers meeting (do not miss more than 3 in a row - special dispensation can be made for difficult time zones)
-* Be available to answer mailing list questions within 48 hours
-* Weekends and local holidays in the maintainer’s jurisdiction are not counted for timeliness requirements. Absences for reasonable causes such as vacations, illness, etc. are also acceptable; Maintainers should notice of absences via the development mailing list whenever possible.
+* Handles contributions on GitHub - first response to a PR within 48 hours
+* Is available on IRC
+* Attends the developers meeting (do not miss more than 3 in a row - special dispensation can be made for difficult time zones)
+* Is available to answer mailing list questions within 48 hours
+* Weekends and local holidays in the Maintainer’s jurisdiction are not counted for timeliness requirements. Absences for reasonable causes such as vacations, illness, etc. are also acceptable; Maintainers should notice of absences via the development mailing list whenever possible.
 * Committed to 100% tests passing for your component
 * Has full commit/merge access to the relevant repositories
 * Has ops on IRC
 
 # Contributing Patches
 
-##How a patch gets merged
+## How a patch gets merged
 
 * Open Pull Request (anyone)
 * Sign a CLA on Supermarket, tied to your github account.
-* Code reviewed by a maintainer, lieutenant, or project lead. Approval is indicated by :+1: on the pull request.
-* Merged on :+1: by an absolute majority of maintainers for the subsystems affected by your patch with no vetoes
+* Code reviewed by a Maintainer, Lieutenant, or Project Lead. Approval is indicated by :+1: on the pull request.
+* Merged after :+1: votes by at least two Maintainers for the component(s) affected by your patch.
+
+In the event that a compontent lacks two Maintainers, the vote of one or more Maintainers from Chef Core may be substituted.
+
+Any Maintainer may vote :-1: on a patch, which increases the requirement for a patch to be merged to an absolute majority of Maintainers for the affected component(s), unless that Maintainer later changes their vote.
 
 ## Patch Appeals Process
 
-Although the approval of a contribution requires an absolute majority of the maintainers responsible for that component to vote for it, there may be cases where someone wishes to appeal a particular decision.
-
-In this event, the "chain of command" for the appeals process is as follows.
+There may be cases where someone wishes to appeal a Maintainer decision. In this event, the "chain of command" for the appeals process is as follows.
 
 * In the event that the actions of a Maintainer are to be appealed, the appeal should be directed to the Lieutenant for that component. As stated above, a Lt retains veto power for the component(s) for which they are responsible.
 
 * In the event that the actions of a Lieutenant are to be appealed, the appeal should be directed to the Project Lead. As stated above, the Project Lead retains universal veto power over all components.
 
-Although Lieutenants and the Project Lead retain veto powers over certain components, use of this veto power is not guaranteed by the submission of an appeal to that person. It is expected that the majority decisions of component maintainers and lieutenants will be respected in all but the most exceptional circumstances.
+Although Lieutenants and the Project Lead retain veto powers over certain components, use of this veto power is not guaranteed by the submission of an appeal to that person. It is expected that the majority decisions of component Maintainers and Lieutenants will be respected in all but the most exceptional circumstances.
 
 # How to become a...
 
 ## Maintainer
 
-* Have patches merged into the relevant subsystem
-* Be willing to perform the duties of a maintainer
+* Have patches merged into the relevant component
+* Be willing to perform the duties of a Maintainer
 * Issue a pull request adding yourself to the MAINTAINERS file for your component
-* Receive an absolute majority of existing maintainers and lieutenants for your component :+1:
-* No veto from the component lieutenant
-* No veto from the current project lead
+* Receive an absolute majority of existing Maintainers and Lieutenants for your component :+1:
+* No veto from the component Lieutenant
+* No veto from the current Project Lead
 
 ## Lieutenant
 
-* Issue a pull request to the MAINTAINERS file making yourself the lieutenant
-* Be willing to perform the duties of a lieutenant
-* Receive an absolute majority of existing lieutenants :+1:
-* No veto from the current project lead
+* Issue a pull request to the MAINTAINERS file making yourself the Lieutenant
+* Be willing to perform the duties of a Lieutenant
+* Receive an absolute majority of existing Lieutenants :+1:
+* No veto from the current Project Lead
 
 ## Project Lead
 
-* Issue a pull request to the MAINTAINERS file making yourself the project lead
-* Be willing to perform the duties of the project lead
-* Receive an absolute majority of existing lieutenants :+1:
+* Issue a pull request to the MAINTAINERS file making yourself the Project Lead
+* Be willing to perform the duties of the Project Lead
+* Receive an absolute majority of existing Lieutenants :+1:
 * No veto from Chef Software, Inc, as held by their current Chief Executive Officer.
 
-# Removing a Maintainer, Lieutenant or Lead
+# Removing a Maintainer, Lieutenant or Project Lead
 
-If a Maintainer, Lieutenant or Lead consistently fails to maintain their responsibilities or becomes disruptive, they can be removed by:
+If a Maintainer, Lieutenant or Project Lead consistently fails to maintain their responsibilities or becomes disruptive, they can be removed by:
 
 * Issue a pull request removing them from the MAINTAINERS file
-* Receive an absolute majority of existing lieutentants :+1:
-* No veto from the current project lead
+* Receive an absolute majority of existing Lieutentants :+1:
+* No veto from the current Project Lead
 
 OR
 
 * Issue a pull request removing them from the MAINTAINERS file
-* The current project lead unilaterally decides to merge pull request
+* The current Project Lead unilaterally decides to merge pull request
 
 # How to add a component
 
-* Issue a pull request to the MAINTAINERS file describing the component, and making yourself lieutenant
-* Be willing to perform the duties of a lieutenant
-* Receive an absolute majority of existing lieutenants :+1:
-* No veto from the current project lead
+* Issue a pull request to the MAINTAINERS file describing the component, and making yourself Lieutenant
+* Be willing to perform the duties of a Lieutenant
+* Receive an absolute majority of existing Lieutenants :+1:
+* No veto from the current Project Lead
 
 # How to change the rules by which the project is maintained
 
 * Issue a pull request to this file.
-* Receive an absolute majority of existing lieutenants from the Chef repository MAINTAINERS file :+1:
-* No veto from the current project lead
+* Receive an absolute majority of existing Lieutenants from the Chef repository MAINTAINERS file :+1:
+* No veto from the current Project Lead
 
 # Where can I find the community?
 
@@ -126,7 +128,7 @@ The broader Chef community gathers in a small number of designated places. Parti
 
 ## IRC
 
-You can find a large set of community members in IRC, within the #chef channel on irc.freenode.net. Development updates and conversations also happen on #chef-hacking. In both channels, those with “ops” are the maintainers, lieutenants, and the project lead. Those with “voice” are MVPs for Chef releases.
+You can find a large set of community members in IRC, within the #chef channel on irc.freenode.net. Development updates and conversations also happen on #chef-hacking. In both channels, those with “ops” are the Maintainers, Lieutenants, and the Project Lead. Those with “voice” are MVPs for Chef releases.
 
 ## Mailing Lists
 
@@ -135,92 +137,10 @@ You can find a large set of community members in IRC, within the #chef channel o
 
 # Where can I find Chef Software Inc?
 
-[The history of the Chef Project](http://www.getchef.com/blog/2014/07/03/chef-as-a-community/) is linked to the existence of a for-profit company, [Chef Software](http://www.getchef.com). Many employees of the company are active members of the community. When they participate in the community, they do so as individuals subject to the guidelines in this file.
+[The history of the Chef Project](http://www.chef.io/blog/2014/07/03/chef-as-a-community/) is linked to the existence of a for-profit company, [Chef Software](http://www.chef.io). Many employees of the company are active members of the community. When they participate in the community, they do so as individuals subject to the guidelines in this file.
 
-If you would like to speak to, or understand the position of, someone at Chef Software - feel free to drop a line to [info@getchef.com](mailto:info@getchef.com) - and we’ll get back to you. Or simply ask for the companies official perspective in any of the community spaces, and a representative will get back to you in that space.
+If you would like to speak to, or understand the position of, someone at Chef Software - feel free to drop a line to [info@chef.io](mailto:info@chef.io) - and we’ll get back to you. Or simply ask for the companies official perspective in any of the community spaces, and a representative will get back to you in that space.
 
 # The MAINTAINERS file in Chef
 
-# Maintainers
-
-This file lists how the Chef project is maintained. When making changes to the system, this
-file tells you who needs to review your patch - you need a simple majority of maintainers
-for the relevant subsystems to provide a :+1: on your pull request. Additionally, you need
-to not receive a veto from a Lieutenant or the Project Lead.
-
-[Check out HOW_CHEF_IS_MAINTAINED](#soon) for details on the process, how to become
-a maintainer, lieutenant, or the project lead.
-
-# Project Lead
-
-[Adam Jacob](http://github.com/adamhjk)
-
-# Components
-
-## Chef Core
-
-Handles the core parts of the Chef DSL, base resource and provider
-infrastructure, and the Chef applications. Includes anything not covered by
-another component.
-
-### Lieutenant
-
-### Maintainers
-
-## Dev Tools
-
-Chef Zero, Knife, Chef Apply and Chef Shell.
-
-### Lieutenant
-
-### Maintainers
-
-## Test Tools
-
-ChefSpec, Berkshelf (the chef bits), Test Kitchen (the Chef bits)
-
-### Lieutenant
-
-### Maintainers
-
-## Platform Specific Components
-
-The specific components of Chef related to a given platform - including (but not limited to) resources, providers, and the core DSL.
-
-## Enterprise Linux
-
-### Lieutenant
-
-### Maintainers
-
-## Ubuntu
-
-### Lieutenant
-
-### Maintainers
-
-## Windows
-
-### Lieutenant
-
-### Maintainers
-
-## Solaris
-
-### Lieutenant
-
-### Maintainers
-
-## AIX
-
-### Lieutenant
-
-### Maintainers
-
-## Mac OS X
-
-### Lieutenant
-
-### Maintainers
-
-
+The current [MAINTAINERS](https://github.com/chef/chef/blob/master/MAINTAINERS.md) file resides in the [Chef](https://github.com/chef/chef) repository on GitHub.


### PR DESCRIPTION
The current maintenance policy requires an absolute majority of maintainers to vote for a patch for it to be merged. Currently with six maintainers, this means four people must approve every patch. Adding
additional maintainers only worsens the situation and thus discourages additional involvement. Primarily this patch changes the requirement to two votes, but also adds the option of a -1 maintainer vote triggering the requirement of a larger majority to facilitate disputes being discussed and resolved without requiring an appeal.

This patch also adds consistency in referring to components, removes the MAINTAINERS file which now exists in the Chef repository, and performs some other minor cleanup for consistency across the document.