### PR TITLE
Remove roadmapping as an LT responsibility

### DIFF
--- a/rfc030-maintenance-policy.md
+++ b/rfc030-maintenance-policy.md
@@ -31,7 +31,6 @@ This file is the canonical source for how the Chef project is maintained.
 
 ## Lieutenant
 
-* Publishes a roadmap (two quarters out)
 * Provides a release calendar for code outside of chef client/chef server
 * Resolves disputes within their component
 * Has localized veto power


### PR DESCRIPTION
As discussed at the 2015-02-19 meeting, LTs won't often have resources to drive
a roadmap themselves, and so it's confusing to expect them to provide one.