### PR TITLE
update maintainers file url to match current version

### DIFF
--- a/rfc030-maintenance-policy.md
+++ b/rfc030-maintenance-policy.md
@@ -169,4 +169,4 @@ If you would like to speak to, or understand the position of, someone at Chef So
 
 # The MAINTAINERS file in Chef
 
-The current [MAINTAINERS](https://github.com/chef/chef/blob/master/MAINTAINERS.md) file resides in the [Chef](https://github.com/chef/chef) repository on GitHub.
+The current [MAINTAINERS](https://github.com/chef/chef/blob/master/MAINTAINERS) file resides in the [Chef](https://github.com/chef/chef) repository on GitHub.

--- a/rfc030-maintenance-policy.md
+++ b/rfc030-maintenance-policy.md
@@ -169,4 +169,4 @@ If you would like to speak to, or understand the position of, someone at Chef So
 
 # The MAINTAINERS file in Chef
 
-The current [MAINTAINERS](https://github.com/chef/chef/blob/master/MAINTAINERS) file resides in the [Chef](https://github.com/chef/chef) repository on GitHub.
+The current [MAINTAINERS](https://github.com/chef/chef/blob/master/MAINTAINERS.toml) file resides in the [Chef](https://github.com/chef/chef) repository on GitHub.


### PR DESCRIPTION
The Markdown file that was previously targeted has been changed to a TOML file, and the url was broken in the RFC. 