### PR TITLE
Propose moving OpenBSD 5.7+ i386 and amd64 into Tier 2 support

### DIFF
--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -53,6 +53,7 @@ Tier 2 supported platforms are those on which Omnitruck will serve packages, but
 * Fedora (current non-EOL revisions)
 * OpenSUSE 12.3 (until EOL on 15 September 2014), 13.1
 * OmniOS stable and LTS releases
+* OpenBSD 5.7 (i386 and amd64)
 
 ### Not Supported
 
@@ -61,7 +62,6 @@ Tier 2 supported platforms are those on which Omnitruck will serve packages, but
 * Solaris < 10
 * AIX 5.1L
 * FreeBSD 8
-* OpenBSD
 * NetBSD
 * Windows 2003, Windows 2000
 * RHEL/CentOS/Oracle/Scientific 4.x or older


### PR DESCRIPTION
I'd like to propose moving OpenBSD 5.7+ (i386, amd64 platforms) from `Not Supported` into `Tier 2 support` group.

I have done some work to the current `openbsd_service` resource to support the new `rcctl(8)` daemon control script functionality released in OpenBSD 5.7 as well as implement missing functionality (namely `flags/parameters` support): https://github.com/chef/chef/pull/3372

This PR is a rewrite of the existing `openbsd_service` resource and would not be compatible on OpenBSD < 5.7. It is possible to support two different providers and use ohai to choose the appropriate one based on version, but it may be simpler to only support 5.7+.

Additionally I have initial omnibus builds of the chef client on OpenBSD 5.7 with this PR: https://github.com/chef/omnibus-software/pull/426 .. It probably needs further work in the verification phase, I'm not sure, and could use some feedback from the release engineering team on what would be needed for "good" omnibus builds.

I have been an OpenBSD user for about a decade but only in a personal/hobby sense. I do not use it at work. I'd be willing to spend time to support the basics of OpenBSD for chef, in particular: omnibus builds, package and service providers.

Additional work I have in mind for OpenBSD:

1. Decide on supporting OpenBSD < 5.7 in the `openbsd_service` provider or not.
2. Improve package selection with certain package "flavors" in the `openbsd_package` provider.
3. Complete, approved, omnibus chef builds... Verification tests? Integration into the build pipeline?

Feedback appreciated. thanks.