### PR TITLE
Propose to support Debian 8 (Jessie) & move Debian to tier 1

### DIFF
--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -33,6 +33,7 @@ Platform | Versions | Architectures | Package Format | Built on
 --- | --- | --- | --- | ---
 AIX | 6.1, 7.1 | ppc64 | bff | AIX 6.1
 CentOS | 5, 6, 7 | i386, x86_64 | rpm | RHEL 5
+Debian Linux | 6, 7, 8 | i386, x86_64 | deb | Debian 6
 FreeBSD | 9, 10 | i386, amd64 | pkg_add pkg | FreeBSD 9
 Mac OS X | 10.8, 10.9, 10.10 | x86_64 | dmg | Mac OS 10.8
 Oracle Enterprise Linux | 5, 6, 7 | i386, x86_64 | rpm | RHEL 5
@@ -47,7 +48,6 @@ Tier 2 supported platforms are those on which Omnitruck will serve packages, but
 
 * SUSE Linux Enterprise Server 10, 11
 * Scientific Linux 5.x, 6.x and 7.x (i386 and x86-64)
-* Debian Linux 6.x and 7.x
 * Ubuntu 10.04 (x86, x86_64)
 * Gentoo Linux (rolling release)
 * Arch Linux (rolling release)


### PR DESCRIPTION
(updated:)

I'd like to propose Debian 8.x support ([What's new in Debian 8](https://www.debian.org/releases/stable/amd64/release-notes/ch-whats-new.en.html)).

Jessie was released in April 2015 and is the current stable release of Debian. Notable changes are the new `systemd` init system.

Related: 
Debian 8.0 bento boxes: https://github.com/chef/bento/commit/5e3ec117459263e9942b00027337d4fa2c5ae584

By popular request, I've also promoted Debian 6, 7, 8 to tier 1 support.