### PR TITLE
Clarify N-1 support policy.

### DIFF
--- a/rfc015-chef-12.md
+++ b/rfc015-chef-12.md
@@ -23,7 +23,7 @@ At a given time:
 
 * `Latest` and `Latest - 1` major versions of Chef Client is supported by Chef community.
 * `Latest` version includes all the enhancements and bug fixes.
-* Security fixes only are backported to `Latest - 1`.
+* Security fixes are backported to `Latest - 1`.
 * Contributions to `Latest - 1` version are always welcome.
 * As Chef Community, we use and strongly recommend using omnibus packages for Chef Client. We still help out to folks who are doing custom installations of Chef Client but on a 'best effort' basis.
 

--- a/rfc015-chef-12.md
+++ b/rfc015-chef-12.md
@@ -23,7 +23,7 @@ At a given time:
 
 * `Latest` and `Latest - 1` major versions of Chef Client is supported by Chef community.
 * `Latest` version includes all the enhancements and bug fixes.
-* The major bug fixes and security fixes are backported to `Latest - 1`.
+* Security fixes only are backported to `Latest - 1`.
 * Contributions to `Latest - 1` version are always welcome.
 * As Chef Community, we use and strongly recommend using omnibus packages for Chef Client. We still help out to folks who are doing custom installations of Chef Client but on a 'best effort' basis.
 


### PR DESCRIPTION
This textual change updates policy to how we are actually behaving.
This gets the messaging correct to Customers and Customer Support.
Since Chef 12 was released in Dec 2014 we did do one release of Chef 11 in
Jan 2015 with new DSC features.  In the past 6 months, however, we have only
released security updates to the chef 11.18.x branch (which is now on
11.18.12 and soon to be 11.18.14).  We did bundle an updated CA certs
package to work around the omission of the root cert that signed all of
Amazon AWSs certs and with AWS SSL certs being entirely broken.  It does
not appear that a new minor release of Chef 11 is likely any time soon
with any bugfixes to chef client core, critical or otherwise.

Users who read "critical bug fixes" and believe that the bug which
ruined their weekend is "critical" and should be fixed in 11.x without
them upgrading to 12 will be disappointed unless we change this policy.

While we clearly reserve the right to push a new 11.x version to fix
earthshattering-the-world-is-broken types of bugs, or to address bugs
which have significant partner benefit, I've dropped that language
entirely since for most users it can only be misconstrued.

For the Customers who feel like this drops support for them, if you look
at the actual behavior of Chef 11 releases, it is clear that this
support was not occurring.  The easiest solution for customers would be
to upgrade to Chef 12 where they will get both security and bug fixes.

Alternatively, the policy that we adopted with Chef 10 backports was to
get a major customer adopting the backporting of fixes from 11 to 10 and
they were made external committers.  If there's interest in the
community by Chef 11 customers who feel it is easier for them to support
backporting to Chef 11 than to get their infrastructure onto Chef 12,
then those Customers should step forwards.