### PR TITLE
Add mailing list moderators after discourse migration.

### DIFF
--- a/ADVOCATES.md
+++ b/ADVOCATES.md
@@ -42,11 +42,12 @@ More information can be found in the [Chef Community Guidelines](https://github.
 * [Mike Fiedler](https://github.com/miketheman)
   * [ServerFault](http://serverfault.com/users/7309/mike-fiedler)
 
-#### chef@ mailing list
-* Vacant - Submit a PR to become a Chef Community Advocate
-
-#### chef-dev@ mailing list
-* Vacant - Submit a PR to become a Chef Community Advocate
+#### Chef Mailing List
+* [Noah Kantrowitz](https://github.com/coderanger)
+* [JJ Asghar](https://github.com/jjasghar)
+* [Mike Fieder](https://github.com/miketheman)
+* [Nell Shamrell-Harrington](https://github.com/nshamrell)
+* [Robb Kidd](https://github.com/robbkidd)
 
 #### GitHub
 * Vacant - Submit a PR to become a Chef Community Advocate

--- a/ADVOCATES.md
+++ b/ADVOCATES.md
@@ -45,7 +45,7 @@ More information can be found in the [Chef Community Guidelines](https://github.
 #### Chef Mailing List
 * [Noah Kantrowitz](https://github.com/coderanger)
 * [JJ Asghar](https://github.com/jjasghar)
-* [Mike Fieder](https://github.com/miketheman)
+* [Mike Fiedler](https://github.com/miketheman)
 * [Nell Shamrell-Harrington](https://github.com/nshamrell)
 * [Robb Kidd](https://github.com/robbkidd)
 

--- a/ADVOCATES.toml
+++ b/ADVOCATES.toml
@@ -45,12 +45,11 @@ More information can be found in the [Chef Community Guidelines](https://github.
     [Org.Advocates.ChefMailingList]
       title = "chef@ mailing list"
       advocates = [
-        "vacant"
-      ]
-    [Org.Advocates.ChefDevMailingList]
-      title = "chef-dev@ mailing list"
-      advocates = [
-        "vacant"
+        "coderanger",
+        "jjasghar",
+        "miketheman",
+        "nshamrell",
+        "robbkidd"
       ]
     [Org.Advocates.GitHub]
       title = "GitHub"

--- a/rfc020-community-guidelines.md
+++ b/rfc020-community-guidelines.md
@@ -94,8 +94,13 @@ The Chef Community advocates are well informed on how to deal with incidents. Re
   * IRC
     * \#chef - jonlives, zts
     * \#chef-hacking - jonlives, zts
-  * chef@ mailing list -
-  * chef-dev@ mailing list -
+  * [Chef Mailing List](http://discourse.chef.io)
+    * [Nathen Harvey](https://discourse.chef.io/users/nathenharvey/),
+    * [Noah Kantrowitz](https://discourse.chef.io/users/coderanger)
+    * [JJ Asghar](https://discourse.chef.io/users/jjasghar)
+    * [Mike Fiedler](https://discourse.chef.io/users/mike)
+    * [Nell Shamrell-Harrington](https://discourse.chef.io/users/nell_shamrell)
+    * [Robb Kidd](https://discourse.chef.io/users/robbkidd)
   * GitHub -
   * Stackoverflow -
   * Serverfault - [Mike Fiedler](http://serverfault.com/users/7309/mike-fiedler),  [GitHub:  miketheman](https://github.com/miketheman)

--- a/rfc030-maintenance-policy.md
+++ b/rfc030-maintenance-policy.md
@@ -64,11 +64,11 @@ Releases should not block on features on the roadmap, rather they should happen 
 # 2015 Q2
 * Component - Roadmap Item
   Description
-  
+
 # 2015 Q4
 * Core - Support for Drone Automation
   Significant time could be saved in enterprise datacenters by using drones to stack and rack servers
- 
+
 # 2016 Q1
 * Core - Support Internet of Things
   As a Chef user, I look forward to the singularity
@@ -158,8 +158,9 @@ You can find a large set of community members in IRC, within the #chef channel o
 
 ## Mailing Lists
 
-* [Chef Users](http://lists.opscode.com/sympa/info/chef) - is the primary async communications channel for all users of Chef, regardless of how they participate.
-* [Chef Developers](http://lists.opscode.com/sympa/info/chef-dev) - is the primary async communications channel for those concerned with developing Chef.
+* [Chef Mailing List](http://discourse.chef.io)
+  * The `chef` category is the primary async communications channel for all users of Chef, regardless of how they participate.
+  * The `chef-dev` is the primary async communications channel for those concerned with developing Chef.
 
 # Where can I find Chef Software Inc?
 


### PR DESCRIPTION
Add mailing list advocates identified during Seattle Summit 2015

Volunteers from the Discourse migration lessons learned session willing
to help moderate the mailing list.