### PR TITLE
Fix link to DEP-1 in django/deps.

### DIFF
--- a/rfc000-rfc-process.md
+++ b/rfc000-rfc-process.md
@@ -165,7 +165,7 @@ neighboring rights to this work.
 ## Influences
 
 This document is heavily based on [PEP 1](http://legacy.python.org/dev/peps/pep-0001/).
-It also draws from [Django's DEP process](https://github.com/django/deps/blob/master/deps/0001.rst),
+It also draws from [Django's DEP process](https://github.com/django/deps/blob/master/final/0001-dep-process.rst),
 and [OpenStack's Blueprints](https://wiki.openstack.org/wiki/Blueprints).
 
 ## Copyright


### PR DESCRIPTION
Django seems to have refactored their DEP structure which broke the link in the attributions section. This is just a quick fix to the link.