### PR TITLE
Chef-Client Exit status

### DIFF
--- a/exit-status.md
+++ b/exit-status.md
@@ -15,15 +15,16 @@ Signal outside tools of specific Chef-Client run status.  Ability to determine r
     so that Test-Kitchen/Vagrant/any outside tool can wait for node to reboot, and continue converging.
     
 ## Specification
-* Chef-apply, Chef-client, Chef-Solo should honor the below exit chef run exit codes
+* Chef applications (e.g. chef-client) that interpret recipes should use the specified exit codes
+* Chef tools (e.g. knife) should behave appropriately for the exit code, or pass it to the user
 
-### Exit codes reserved across platforms
+### Exit codes Reserved by Operating System
 * Windows- [Link](https://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx)
 * Linux - [Sysexits](http://www.freebsd.org/cgi/man.cgi?query=sysexits&apropos=0&sektion=0&manpath=FreeBSD+4.3-RELEASE&format=html), [Bash Scripting](http://tldp.org/LDP/abs/html/exitcodes.html)
  
 
-### Exit Codes usable across platforms
-All exit codes defined should be usable on all supported Chef Platforms.  Also the exit codes used should be idential across platforms.  That limits the total range from 1-255.  Exit codes not explicitly used by Linux/Windows are listed below.  There are a total of 59 exit codes that overlap between the two platforms.
+### Remaining Available Exit Codes
+All exit codes defined should be usable on all supported Chef Platforms.  Also the exit codes used should be idential across platforms.  That limits the total range from 1-255.  Exit codes not explicitly used by Linux/Windows are listed below.  There are 59 exit codes that are available on both platforms.
  
  * Exit Codes Available for Chef use:
      * ~~35,37,40,41,42~~,43,44,45,46,47,48,49,79,81,90,91,92,93,94,95,96,97
@@ -41,7 +42,7 @@ All exit codes defined should be usable on all supported Chef Platforms.  Also t
 Exit Code        | Reason            | Details
 -------------    | -------------     |-----
 35               | Reboot Scheduled  | Reboot has been scheduled in the run state
-37               | Reboot Pending    | Reboot needs to be completed 
+37               | Reboot Needed     | Reboot needs to be completed 
 40               | Reboot Now        | Reboot being scheduled means it might run eventually.  Forced means its rebooting now
 41               | Reboot Failed     | Initiated Reboot failed - due to permissions or any other reason
 
@@ -52,12 +53,13 @@ Exit Code        | Reason             | Details
 0                | Successful run     | Any successful execution of a Chef utility should return this exit code
 42               | Audit Mode Failure |  Audit mode failed, but chef converged successfully.
 1                | Failed execution   | Generic error during Chef execution.  
--1               | Failed execution   | Generic error during Chef execution.  On Linux this will show up as 255, on Windows as -1  
+-1               | Failed execution*   | Generic error during Chef execution.  On Linux this will show up as 255, on Windows as -1  
 
+* \*Next release should deprecate any use of this exit code.
 
 
 ## Extend
-This RFC should be able to be ammended to include additional exit code functionality at a later date
+This RFC should be able to be amended to include additional exit code functionality at a later date.  Additional exit codes are assigned by pull request against this RFC as detailed in [RFC000](https://github.com/chef/chef-rfc/blob/master/rfc000-rfc-process.md#changing-an-accepted-rfc)
 
 ## Copyright
 

--- a/exit-status.md
+++ b/exit-status.md
@@ -7,7 +7,7 @@ Type: Standards Track
 
 # Title
 
-Signal outside tools of specific Chef-Client run status.  Ability to determine different results of a Chef-Client run.
+Signal outside tools of specific Chef-Client exit status. 
 
 ## Motivation
 
@@ -25,7 +25,7 @@ Signal outside tools of specific Chef-Client run status.  Ability to determine d
 
 ## Specification
 
-Chef-apply, Chef-client, Chef-Solo should honor the below exit codes
+Chef-apply, Chef-client, Chef-Solo should honor the below exit codes.  
 ### Use Exit codes
 Enumeration      | Exit Code    |Description
 -------------    | -------------| -----

--- a/exit-status.md
+++ b/exit-status.md
@@ -67,12 +67,16 @@ Exit Code           | Phase                             |Details
 Exit Code           | Phase                 |Details
 -------------       | -------------|        -----
 24001               | Reboot Scheduled      | Reboot has been scheduled in the run state
-20002               | Reboot Pending        | Reboot needs to be completed 
-20003               | Reboot Now            | Reboot being scheduled means it might run eventually.  Forced means its rebooting now
-20004               | Reboot Failed         | Initiated Reboot failed - due to permissions or any other reason
+24002               | Reboot Pending        | Reboot needs to be completed 
+24003               | Reboot Now            | Reboot being scheduled means it might run eventually.  Forced means its rebooting now
+24004               | Reboot Failed         | Initiated Reboot failed - due to permissions or any other reason
 
-
-
+#### Bootstrap Failures
+Exit Code           | Phase                         |Details
+-------------       | -------------|                -----
+25001               | chef-client download failure  | 
+25002               | Authentication failure        | 
+25003               | Environment doesn't exist     | 
 
 ## Copyright
 

--- a/exit-status.md
+++ b/exit-status.md
@@ -31,8 +31,17 @@ All exit codes defined should be usable on all supported Chef Platforms.  Also t
      * 213,219,227,228,235,236,237,238,239,241,242,243,244,245
 
 ## Exit Codes in Use
+
+#### Chef Run Generic
+Exit Code        | Reason            | Details
+-------------    | -------------     |-----
+0                | Successful run    | Any successful execution of a Chef utility should return this exit code
+1                | Failed execution  | Generic error during Chef execution.  
+-1               | Failed execution  | Generic error during Chef execution.  
+
+
 #### Reboot Requirement
-Exit Code        | Phase             | Details
+Exit Code        | Reason            | Details
 -------------    | -------------     |-----
 35               | Reboot Scheduled  | Reboot has been scheduled in the run state
 37               | Reboot Pending    | Reboot needs to be completed 

--- a/exit-status.md
+++ b/exit-status.md
@@ -52,7 +52,7 @@ Exit Code        | Reason             | Details
 0                | Successful run     | Any successful execution of a Chef utility should return this exit code
 42               | Audit Mode Failure |  Audit mode failed, but chef converged successfully.
 1                | Failed execution   | Generic error during Chef execution.  
--1               | Failed execution   | Generic error during Chef execution.  
+-1               | Failed execution   | Generic error during Chef execution.  On Linux this will show up as 255, on Windows as -1  
 
 
 

--- a/exit-status.md
+++ b/exit-status.md
@@ -33,7 +33,8 @@ Success          | 0            | When Chef executes with a successful convergen
 Generic Failure  | 1            | When Chef executes and fails at convergence
 Compile Failure  | 50           | When Chef executes and Compile time phase fails
 Reboot           | 51           | When Chef executes and reboot is scheduled
-Audit Failure    | 52           | When Chef executes and chef succeeds but Audit fails
+Reboot (Pending) | 52           | When Chef executes and reboot is pending. 
+Audit Failure    | 53           | When Chef executes and chef succeeds but Audit fails
 
 This list should be able to be expanded.  We should be conscious of typical exit codes that are used.  Example, Windows exit code 5 is commonly used for access denied.
 

--- a/exit-status.md
+++ b/exit-status.md
@@ -39,7 +39,7 @@ Multiple exit code ranges should be supported.  This allows reasoning of which c
 ### Ranges
 Exit Code Range      | Enumeration Meaning                  |Details
 -------------       | -------------|                        -----
-20000-20999          | Chef Phase Failures                  | Any Chef specific Phase failure. Compile, Converge, Audit, etc  Further subdivide into smaller subsets.
+20000-20999          | Chef Phase Failures                  | Any Chef specific Phase failure. Compile, Converge, Audit, etc 
 24000-24999         | Reboot, or other user requirement    | Any exit code for rebooting, reboot pending, etc.
 25000-25999         | Bootstrap Failures                    | Specific reasons why bootstrap failed.  i.e. Download of chef-client installer failed, Install failed, Authentication, 
 

--- a/exit-status.md
+++ b/exit-status.md
@@ -17,7 +17,7 @@ Signal outside tools of specific Chef-Client run status.  Ability to determine r
 ## Specification
 * Chef-apply, Chef-client, Chef-Solo should honor the below exit chef run exit codes
 
-### Exit codes in use across platforms
+### Exit codes reserved across platforms
 * Windows- [Link](https://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx)
 * Linux - [Sysexits](http://www.freebsd.org/cgi/man.cgi?query=sysexits&apropos=0&sektion=0&manpath=FreeBSD+4.3-RELEASE&format=html), [Bash Scripting](http://tldp.org/LDP/abs/html/exitcodes.html)
  

--- a/exit-status.md
+++ b/exit-status.md
@@ -7,76 +7,41 @@ Type: Standards Track
 
 # Title
 
-Signal outside tools of specific Chef-Client run status.  Ability to determine different results of a Chef-Client run.
+Signal outside tools of specific Chef-Client run status.  Ability to determine results of a Chef-Client run.
 
 ## Motivation
-
     As a Chef user,
     I want to be able to determine when a chef-client run is rebooting the node,
     so that Test-Kitchen/Vagrant/any outside tool can wait for node to reboot, and continue converging.
     
-    As a Chef user,
-    I want to be able to determine when a chef-client run succeeds but fails Audit mode,
-    so I can tell if converge failed and/or auditing failed.
-    
-    As a Chef user/support engineer,
-    I want to know which stage of a chef-client run failed (Compile, Converge, etc),
-    so that I can limit my debugging of failed chef-client runs
-    
-
 ## Specification
 * Chef-apply, Chef-client, Chef-Solo should honor the below exit chef run exit codes
-* Knife bootstrap and Knife windows bootstrap should honor bootstrap exit codes
 
-### Exit Code Ranges
-Multiple exit code ranges should be supported.  This allows reasoning of which components are trying to signal the external tools.  Also this will allow future expansion of this Spec to include additional codes.  
- * Example - additonal phases of Chef-client run.
-
-### Exit code ranges/codes to exclude
-* Windows - [1 - 16000](https://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx)
-* Linux 1 - 255 - [Sysexits](http://www.freebsd.org/cgi/man.cgi?query=sysexits&apropos=0&sektion=0&manpath=FreeBSD+4.3-RELEASE&format=html), [Bash Scripting](http://tldp.org/LDP/abs/html/exitcodes.html), Linux generally supports this range
+### Exit codes in use across platforms
+* Windows- [Link](https://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx)
+* Linux - [Sysexits](http://www.freebsd.org/cgi/man.cgi?query=sysexits&apropos=0&sektion=0&manpath=FreeBSD+4.3-RELEASE&format=html), [Bash Scripting](http://tldp.org/LDP/abs/html/exitcodes.html)
  
-### Ranges
-Exit Code Range      | Enumeration Meaning                  |Details
--------------       | -------------|                        -----
-20000-20999          | Chef Phase Failures                  | Any Chef specific Phase failure. Compile, Converge, Audit, etc 
-24000-24999         | Reboot, or other user requirement    | Any exit code for rebooting, reboot pending, etc.
-25000-25999         | Bootstrap Failures                    | Specific reasons why bootstrap failed.  i.e. Download of chef-client installer failed, Install failed, Authentication, 
 
-#### Precedence
-* Chef-Client order of precendence (highest on top):
-    1. Reboot, any other use interactions 
-    2. Chef Phase Failures
+### Exit Codes usable across platforms
+All exit codes defined should be usable on all supported Chef Platforms.  Also the exit codes used should be idential across platforms.  That limits the total range from 1-255.  Exit codes not explicitly used by Linux/Windows are listed below.  There are a total of 59 exit codes that overlap between the two platforms.
+ 
+ * Exit Codes Available for Chef use:
+     * ~~35,37,40,41~~,42,43,44,45,46,47,48,49,79,81,90,91,92,93,94,95,96,97
+     * 98,99,115,116,168,169,172,175,176,177,178,179,181,184,185,204,211
+     * 213,219,227,228,235,236,237,238,239,241,242,243,244,245
 
-#### Chef Phase Failures
-Exit Code           | Phase                             |Details
--------------       | -------------|                    -----
-20001               | Get configuration data            | [See here](https://docs.chef.io/chef_client.html)
-20002               | Authenticate to the Chef Server   | [See here](https://docs.chef.io/chef_client.html)
-20003               | Get, rebuild the node object      | [See here](https://docs.chef.io/chef_client.html)
-20004               | Expand the run-list               | [See here](https://docs.chef.io/chef_client.html)
-20005               | Synchronize cookbooks             | [See here](https://docs.chef.io/chef_client.html)
-20006               | Reset node attributes             | [See here](https://docs.chef.io/chef_client.html)
-20007               | Compile the resource collection   | [See here](https://docs.chef.io/chef_client.html)
-20008               | Converge the node                 | [See here](https://docs.chef.io/chef_client.html)
-20009               | Update the node object            | [See here](https://docs.chef.io/chef_client.html)
-20010               | Process exception/report handlers | [See here](https://docs.chef.io/chef_client.html)
-20011               | Audit Mode                        | [See here](https://docs.chef.io/chef_client.html)
+## Exit Codes in Use
+#### Reboot Requirement
+Exit Code        | Phase             | Details
+-------------    | -------------     |-----
+35               | Reboot Scheduled  | Reboot has been scheduled in the run state
+37               | Reboot Pending    | Reboot needs to be completed 
+40               | Reboot Now        | Reboot being scheduled means it might run eventually.  Forced means its rebooting now
+41               | Reboot Failed     | Initiated Reboot failed - due to permissions or any other reason
 
-#### Reboot or other User Requirement
-Exit Code           | Phase                 |Details
--------------       | -------------|        -----
-24001               | Reboot Scheduled      | Reboot has been scheduled in the run state
-24002               | Reboot Pending        | Reboot needs to be completed 
-24003               | Reboot Now            | Reboot being scheduled means it might run eventually.  Forced means its rebooting now
-24004               | Reboot Failed         | Initiated Reboot failed - due to permissions or any other reason
 
-#### Bootstrap Failures
-Exit Code           | Phase                         |Details
--------------       | -------------|                -----
-25001               | chef-client download failure  | 
-25002               | Authentication failure        | 
-25003               | Environment doesn't exist     | 
+## Extend
+This RFC should be able to be ammended to include additional exit code functionality at a later date
 
 ## Copyright
 

--- a/exit-status.md
+++ b/exit-status.md
@@ -1,0 +1,45 @@
+---
+RFC: unassigned
+Author: Nicholas Carpenter <ncarpenter@ebsco.com>
+Status: Draft
+Type: Standards Track
+---
+
+# Title
+
+Signal outside tools of specific Chef-Client run status.  Ability to determine different results of a Chef-Client run.
+
+## Motivation
+
+    As a Chef user,
+    I want to be able to determine when a chef-client run is rebooting the node,
+    so that Test-Kitchen/Vagrant/any outside tool can wait for node to reboot, and continue converging.
+    
+    As a Chef user,
+    I want to be able to determine when a chef-client run succeeds but fails Audit mode,
+    so I can tell if converge failed and/or auditing failed.
+    
+    As a Chef user,
+    I want to know which stage of a chef-client run failed (Compile, Converge, etc),
+    so that I can limit my debugging of failed chef-client runs
+
+## Specification
+
+Chef-apply, Chef-client, Chef-Solo should honor the below exit codes
+### Use Exit codes
+Enumeration      | Exit Code    |Description
+-------------    | -------------| -----
+Success          | 0            | When Chef executes with a successful convergence and Audit Success
+Generic Failure  | 1            | When Chef executes and fails at convergence
+Compile Failure  | 50           | When Chef executes and Compile time phase fails
+Reboot           | 51           | When Chef executes and reboot is scheduled
+Audit Failure    | 52           | When Chef executes and chef succeeds but Audit fails
+
+This list should be able to be expanded.  We should be conscious of typical exit codes that are used.  Example, Windows exit code 5 is commonly used for access denied.
+
+## Copyright
+
+This work is in the public domain. In jurisdictions that do not allow for this,
+this work is available under CC0. To the extent possible under law, the person
+who associated CC0 with this work has waived all copyright and related or
+neighboring rights to this work.

--- a/exit-status.md
+++ b/exit-status.md
@@ -26,19 +26,16 @@ Signal outside tools of specific Chef-Client run status.  Ability to determine r
 All exit codes defined should be usable on all supported Chef Platforms.  Also the exit codes used should be idential across platforms.  That limits the total range from 1-255.  Exit codes not explicitly used by Linux/Windows are listed below.  There are a total of 59 exit codes that overlap between the two platforms.
  
  * Exit Codes Available for Chef use:
-     * ~~35,37,40,41~~,42,43,44,45,46,47,48,49,79,81,90,91,92,93,94,95,96,97
+     * ~~35,37,40,41,42~~,43,44,45,46,47,48,49,79,81,90,91,92,93,94,95,96,97
      * 98,99,115,116,168,169,172,175,176,177,178,179,181,184,185,204,211
      * 213,219,227,228,235,236,237,238,239,241,242,243,244,245
 
+### Precedence
+* Reboot exit codes should take precedence over Chef Execution State
+* Precedence within a table should be evaluated from the top down.
+    *  Example - Audit Mode Failure would only apply on a successful execution.  But if the chef-run failed for any other reason, no reason to exit with audit mode.
+
 ## Exit Codes in Use
-
-#### Chef Run Generic
-Exit Code        | Reason            | Details
--------------    | -------------     |-----
-0                | Successful run    | Any successful execution of a Chef utility should return this exit code
-1                | Failed execution  | Generic error during Chef execution.  
--1               | Failed execution  | Generic error during Chef execution.  
-
 
 #### Reboot Requirement
 Exit Code        | Reason            | Details
@@ -47,6 +44,16 @@ Exit Code        | Reason            | Details
 37               | Reboot Pending    | Reboot needs to be completed 
 40               | Reboot Now        | Reboot being scheduled means it might run eventually.  Forced means its rebooting now
 41               | Reboot Failed     | Initiated Reboot failed - due to permissions or any other reason
+
+
+#### Chef Run State
+Exit Code        | Reason             | Details
+-------------    | -------------      |-----
+0                | Successful run     | Any successful execution of a Chef utility should return this exit code
+42               | Audit Mode Failure |  Audit mode failed, but chef converged successfully.
+1                | Failed execution   | Generic error during Chef execution.  
+-1               | Failed execution   | Generic error during Chef execution.  
+
 
 
 ## Extend

--- a/exit-status.md
+++ b/exit-status.md
@@ -25,8 +25,8 @@ Signal outside tools of specific Chef-Client run status.  Ability to determine r
 
 ### Remaining Available Exit Codes
 All exit codes defined should be usable on all supported Chef Platforms.  Also the exit codes used should be idential across platforms.  That limits the total range from 1-255.  Exit codes not explicitly used by Linux/Windows are listed below.  There are 59 exit codes that are available on both platforms.
- 
- * Exit Codes Available for Chef use:
+ * Any numbers below that have a strike-through are used below in the **Exit Codes in Use** section
+ * Exit Codes Available for Chef use :
      * ~~35,37,40,41,42~~,43,44,45,46,47,48,49,79,81,90,91,92,93,94,95,96,97
      * 98,99,115,116,168,169,172,175,176,177,178,179,181,184,185,204,211
      * 213,219,227,228,235,236,237,238,239,241,242,243,244,245
@@ -43,7 +43,7 @@ Exit Code        | Reason            | Details
 -------------    | -------------     |-----
 35               | Reboot Scheduled  | Reboot has been scheduled in the run state
 37               | Reboot Needed     | Reboot needs to be completed 
-40               | Reboot Now        | Reboot being scheduled means it might run eventually.  Forced means its rebooting now
+40               | Reboot Now        | The system is rebooting
 41               | Reboot Failed     | Initiated Reboot failed - due to permissions or any other reason
 
 


### PR DESCRIPTION
@adamedx @fnichol @mwrock 

At Chef Summit we discussed using Exit codes to determine what was going on inside a Chef run.  Primary use case at the time was for Windows nodes needing to reboot and testing it within Test-Kitchen.

There is an [open issue](https://github.com/chef/chef/issues/3916) that we plan on submitting a PR for that will handle the default --fork use case.  But before making the change, would like to get it discussed here.

If there are more use cases, please list and I will add them to the table.