### PR TITLE
add 'gem' to cookbook metadata

### DIFF
--- a/new/metadata-gem-installation.md
+++ b/new/metadata-gem-installation.md
@@ -31,7 +31,7 @@ The implementation will use an in-memory bundler Gemfile which is constructed ag
 at the same time.  The syntax of the 'gem' statement will support the bundler gem syntax, with the qualification that since it is compiled into metadata.json
 that arbitrary ruby code will be expanded at cookbook upload time.
 
-The resulting gemset bundle will be installed into the ruby that chef-client is running out of (typically omnibus ruby).
+The resulting gemset bundle will be installed into the LIBPATH of the running chef-client.  This may either be directly into the base ruby libraries (per current `chef_gem` behavior) or into a custom location with the LIBPATH of the chef-client extended to use that location--as an open implementation question.
 
 The normal Gemfile `requires` tag may be used by users to autoload files out of gems.
 

--- a/new/metadata-gem-installation.md
+++ b/new/metadata-gem-installation.md
@@ -23,9 +23,17 @@ Allow users to specify additional gem dependencies like:
 
 gem "poise"
 gem "chef-sugar"
+gem "chef-provisioning"
 
-In the Chef::RunContext::CookbookCompiler#compile method a phase will be added before `compile_libraires` which will install all of the gem declarations from all of the synchronized cookbooks before any other
-cookbook code is compiled.
+In the `Chef::RunContext::CookbookCompiler#compile` method a phase will be added before `compile_libraires` which will install all of the gem declarations from all of the synchronized cookbooks before any other cookbook code is compiled.
+
+The implementation will use an in-memory bundler Gemfile which is constructed against all gem statements in all cookbooks which are in the `run_list`, solved
+at the same time.  The syntax of the 'gem' statement will support the bundler gem syntax, with the qualification that since it is compiled into metadata.json
+that arbitrary ruby code will be expanded at cookbook upload time.
+
+The resulting gemset bundle will be installed into the ruby that chef-client is running out of (typically omnibus ruby).
+
+The normal Gemfile `requires` tag may be used by users to autoload files out of gems.
 
 ## Copyright
 

--- a/new/metadata-gem-installation.md
+++ b/new/metadata-gem-installation.md
@@ -15,7 +15,7 @@ other cookbook loading is done.
 
     As a Chef User,
     I want to be able to use additional gems in libraries, attributes and resources,
-    So I don't pull my hair/beard out in frustration.
+    to avoid complex workarounds and double-run converges.
 
 ## Specification
 

--- a/new/metadata-gem-installation.md
+++ b/new/metadata-gem-installation.md
@@ -25,7 +25,7 @@ gem "poise"
 gem "chef-sugar"
 gem "chef-provisioning"
 
-In the `Chef::RunContext::CookbookCompiler#compile` method a phase will be added before `compile_libraires` which will install all of the gem declarations from all of the synchronized cookbooks before any other cookbook code is compiled.
+In the `Chef::RunContext::CookbookCompiler#compile` method a phase will be added before `compile_libraries` which will install all of the gem declarations from all of the synchronized cookbooks before any other cookbook code is compiled.
 
 The implementation will use an in-memory bundler Gemfile which is constructed against all gem statements in all cookbooks which are in the `run_list`, solved
 at the same time.  The syntax of the 'gem' statement will support the bundler gem syntax, with the qualification that since it is compiled into metadata.json

--- a/new/metadata-gem-installation.md
+++ b/new/metadata-gem-installation.md
@@ -1,0 +1,35 @@
+---
+RFC: unassigned
+Author: Lamont Granquist <lamont@chef.io>
+Status: Draft
+Type: Standards Track
+---
+
+# Title
+
+Support a 'gem' DSL method for cookbook metadata to create a dependency on a rubygem.  The
+gem will be installed via `chef_gem` after all the cookbooks are synchronized but before any
+other cookbook loading is done.
+
+## Motivation
+
+    As a Chef User,
+    I want to be able to use additional gems in libraries, attributes and resources,
+    So I don't pull my hair/beard out in frustration.
+
+## Specification
+
+Allow users to specify additional gem dependencies like:
+
+gem "poise"
+gem "chef-sugar"
+
+In the Chef::RunContext::CookbookCompiler#compile method a phase will be added before `compile_libraires` which will install all of the gem declarations from all of the synchronized cookbooks before any other
+cookbook code is compiled.
+
+## Copyright
+
+This work is in the public domain. In jurisdictions that do not allow for this,
+this work is available under CC0. To the extent possible under law, the person
+who associated CC0 with this work has waived all copyright and related or
+neighboring rights to this work.


### PR DESCRIPTION
Allow cookbooks to specify gems in metadata.rb/metadata.json:

gem 'poise'
gem 'chef-sugar'

And those will be installed right after synchronization and usable in libraries, etc.