### PR TITLE
Change Ohai version numbers to match Chef

### DIFF
--- a/new/reversion_ohai.md
+++ b/new/reversion_ohai.md
@@ -20,13 +20,14 @@ numbers were aligned.
 
 ## Specification
 
-Ohai be renumbered to 12.x.0, where x is the same as the current
-development minor version of Chef. Chef would then have a pessimistic version
-pin to Ohai of "~> 12.x.0", and Ohai would have a similar pessimistic
+Ohai will be renumbered to 12.x.y, where x and y are the current development
+minor and patch versions of Chef. Chef would then have a equality version
+pin to Ohai of "= 12.x.y", and Ohai would have a similar equality
 pin to ChefConfig.
 
-When Chef or Ohai update their minor version, the other must do so in
-lockstep.
+The version bot currently used to automatically change version numbers
+for Chef would also be used for Ohai, and any changes to Ohai would
+similarly cause version bumps for Chef and Ohai.
 
 The change from 8 to 12 would not be considered a
 major version bump for API impact considerations, so no deprecated

--- a/new/reversion_ohai.md
+++ b/new/reversion_ohai.md
@@ -1,0 +1,45 @@
+---
+RFC: unassigned
+Author: Thom May <thom@chef.io>
+Status: Draft
+Type: Process
+---
+
+# Change Ohai version numbers to match Chef
+
+In general, Ohai and Chef are released together, and their functionality
+is interdependent. It would be much simpler to reason about how
+functionality added to either would affect the other if their version
+numbers were aligned.
+
+## Motivation
+
+    As a developer,
+    I want to use the correct version of Ohai,
+    so that releases of Chef and Ohai work properly.
+
+## Specification
+
+Ohai be renumbered to 12.x.0, where x is the same as the current
+development minor version of Chef. Chef would then have a pessimistic version
+pin to Ohai of "~> 12.x.0", and Ohai would have a similar pessimistic
+pin to ChefConfig.
+
+When Chef or Ohai update their minor version, the other must do so in
+lockstep.
+
+The change from 8 to 12 would not be considered a
+major version bump for API impact considerations, so no deprecated
+functionality would be removed.
+
+## Downstream Impact
+
+Any library which version pins to Ohai < 9.0 would need to be updated to
+be < 13.0.
+
+## Copyright
+
+This work is in the public domain. In jurisdictions that do not allow for this,
+this work is available under CC0. To the extent possible under law, the person
+who associated CC0 with this work has waived all copyright and related or
+neighboring rights to this work.

--- a/new/reversion_ohai.md
+++ b/new/reversion_ohai.md
@@ -26,8 +26,8 @@ pin to Ohai of "= 12.x.y", and Ohai would have a similar equality
 pin to ChefConfig.
 
 The version bot currently used to automatically change version numbers
-for Chef would also be used for Ohai, and any changes to Ohai would
-similarly cause version bumps for Chef and Ohai.
+for Chef would also be used to update Ohai's version number when Chef is
+bumped.
 
 The change from 8 to 12 would not be considered a
 major version bump for API impact considerations, so no deprecated

--- a/rfc047-release-process.md
+++ b/rfc047-release-process.md
@@ -103,17 +103,21 @@ A text file named VERSION exists at the top of chef git repository which contain
 
 The VERSION constants, Chef::VERSION and ChefConfig::VERSION are automatically updated by the processes below. The full version, i.e. MAJOR.MINOR.BUILD, is stored as annotated git tags.
 
+Ohai's version shall be the same as Chef's, and updated by the same
+process at the same time.
+
 The following steps will be automated:
 
 ##### Github Bot
 1. Blocks merge on Github with a 'required status check'
 1. Waits for a comment indicating the PR is accepted, e.g. "@shipment approve"
-1. Examines the VERSION file on master to determine MAJOR.MINOR
+1. Examines the VERSION file on `chef/chef` master to determine MAJOR.MINOR
 1. Uses existing tags to determine the next incremental BUILD
-1. Checks out the branch
-1. Update the VERSION constants for the build and commits locally
-1. Merges the branch with the version commit to master
-1. Pushes master to Github
+1. For both `chef/chef` and `chef/ohai`
+  1. Checks out the branch
+  1. Update the VERSION constants for the build and commits locally
+  1. Merges the branch with the version commit to master
+  1. Pushes master to Github
 
 ##### Build Tool
 1. Monitors the repository for commits using Github web hooks or git polling


### PR DESCRIPTION
The main intentions are to make it easier to do CI by ensuring that version numbers are simplified and more consistent, and to ensure that dependencies on Chef/Ohai/ChefConfig are clear and well understood.