### PR TITLE
Clarify that AIX 7.2 is supported.

### DIFF
--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -31,7 +31,7 @@ Tier 1 supported platforms are those for which Chef builds native binary "Omnitr
 
 Platform | Versions | Architectures | Package Format | Built on
 --- | --- | --- | --- | ---
-AIX | 6.1, 7.1 | ppc64 | bff | AIX 6.1
+AIX | 6.1, 7.1, 7.2 | ppc64 | bff | AIX 6.1
 CentOS | 5, 6, 7 | i386, x86_64 | rpm | RHEL 5
 Cisco IOS XR | 6 | x86_64 | rpm | Cisco IOS XR 6 Developer Image
 Cisco NX-OS | 7 | x86_64 | rpm | Cisco NX-OX 7 Developer Image


### PR DESCRIPTION
This is to clarify that AIX 7.2 is supported by virtue of binary compat with AIX 7.1 (and 6.1 too, since we actually build on 6.1)