### PR TITLE
do not deprecate exit code 3

### DIFF
--- a/rfc062-exit-status.md
+++ b/rfc062-exit-status.md
@@ -60,7 +60,7 @@ Exit Code        | Reason             | Details
 42               | Audit Mode Failure | Audit mode failed, but chef converged successfully.
 1                | Failed execution   | Generic error during Chef execution.
 2                | SIGINT received*   | Received an interrupt signal
-3                | SIGTERM received*   | Received an terminate signal
+3                | SIGTERM received   | Received an terminate signal
 -1               | Failed execution*   | Generic error during Chef execution.  On Linux this will show up as 255, on Windows as -1
 
 * \*Next release should deprecate any use of this exit code.

--- a/rfc062-exit-status.md
+++ b/rfc062-exit-status.md
@@ -59,7 +59,7 @@ Exit Code        | Reason             | Details
 0                | Successful run     | Any successful execution of a Chef utility should return this exit code
 42               | Audit Mode Failure | Audit mode failed, but chef converged successfully.
 1                | Failed execution   | Generic error during Chef execution.
-2                | SIGINT received*   | Received an interrupt signal
+2                | SIGINT received    | Received an interrupt signal
 3                | SIGTERM received   | Received an terminate signal
 -1               | Failed execution*   | Generic error during Chef execution.  On Linux this will show up as 255, on Windows as -1
 


### PR DESCRIPTION
The exit code 3 is useful to prevent service management systems from
marking the service as failed when they are explicitly stopped.

An example using this functionality is here:
https://github.com/chef-cookbooks/chef-client/pull/389