### PR TITLE
Registering prefix for Signal Sciences

### DIFF
--- a/rfc078-supermarket-prefix.md
+++ b/rfc078-supermarket-prefix.md
@@ -60,6 +60,7 @@ To register a prefix, fork this repository and create a Pull Request adding
 your prefix and the person or organization that will be responsible for it.
 
 * `poise` - [coderanger](https://github.com/coderanger)
+* `sigsci` - [signalsciences] (https://github.com/signalsciences)
 
 ## Copyright
 


### PR DESCRIPTION
https://signalsciences.com/