### PR TITLE
Update rfc062-exit-status.md

### DIFF
--- a/rfc062-exit-status.md
+++ b/rfc062-exit-status.md
@@ -34,7 +34,7 @@ All exit codes defined should be usable on all supported Chef Platforms.  Also t
  * Exit Codes Available for Chef use :
      * ~~35,37,40,41,42~~,43,44,45,46,47,48,49,79,81,90,91,92,93,94,95,96,97
      * 98,99,115,116,168,169,172,175,176,177,178,179,181,184,185,204,211
-     * 213,219,227,228,235,236,237,238,239,241,242,243,244,245
+     * ~~213~~,219,227,228,235,236,237,238,239,241,242,243,244,245
 
 ### Precedence
 
@@ -57,12 +57,13 @@ Exit Code        | Reason            | Details
 
 Exit Code        | Reason             | Details
 -------------    | -------------      |-----
+-1               | Failed execution*   | Generic error during Chef execution.  On Linux this will show up as 255, on Windows as -1
 0                | Successful run     | Any successful execution of a Chef utility should return this exit code
-42               | Audit Mode Failure | Audit mode failed, but chef converged successfully.
 1                | Failed execution   | Generic error during Chef execution.
 2                | SIGINT received    | Received an interrupt signal
 3                | SIGTERM received   | Received an terminate signal
--1               | Failed execution*   | Generic error during Chef execution.  On Linux this will show up as 255, on Windows as -1
+42               | Audit Mode Failure | Audit mode failed, but chef converged successfully.
+213              | Chef upgrade       | Chef has exited during a client upgrade
 
 * \*Next release should deprecate any use of this exit code.
 

--- a/rfc070-chef-upgrade.md
+++ b/rfc070-chef-upgrade.md
@@ -29,7 +29,7 @@ Users should be able to automatically upgrade to the desired version of chef wit
 
 At the beginning of each chef run, the client should decide whether or not to upgrade, based on configuration supplied by the administrator.
 
-If the administrator has specified a version of chef different to the one currently running, the chef client should check with an update service to ensure the specified version is available. If so, the client will download the specified version, and install it appropriately. The client run should then exit, using an appropriate exit code to signal an upgrade.
+If the administrator has specified a version of chef different to the one currently running, the chef client should check with an update service to ensure the specified version is available. If so, the client will download the specified version, and install it appropriately. The client run will then exit with exit code 213 to signal an upgrade has occurred as defined in RFC 62.
 
 ### Determining the desired chef version
 


### PR DESCRIPTION
Add an exit code for chef upgrades. This would initially be used by the omnibus_updater cookbook when the client exits so that users an write kitchen configs which expect that code and run again. This allows users to test their upgrade process locally before pushing it out to even a dev environment, where a failure could impact the business.