### PR TITLE
Add Sous Chefs to reserved prefixes

### DIFF
--- a/rfc078-supermarket-prefix.md
+++ b/rfc078-supermarket-prefix.md
@@ -64,6 +64,7 @@ your prefix and the person or organization that will be responsible for it.
 * `fb` - [Faceboook](https://github.com/facebook)
 * `gcp` - [googlecloudplatform](https://github.com/googlecloudplatform)
 * `poise` - [coderanger](https://github.com/coderanger)
+* `sc` - [Sous Chefs](https://github.com/sous-chefs)
 * `sigsci` - [signalsciences] (https://github.com/signalsciences)
 
 ## Copyright


### PR DESCRIPTION
This is a proposal to add [Sous Chefs](https://github.com/sous-chefs) to the registered prefixes.

Chef Brigade has agreed to do this, so we're ready to merge.