### PR TITLE
Fix HTML Rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,10 @@
 source "https://rubygems.org"
 
-group(:docgen) do
-  gem "tomlrb"
-
+group :docgen do
+  gem "erubis"
   # Require the Markdown converter gem
-  gem 'metadown', github: "steveklabnik/metadown"
-
-  gem 'pygments.rb'
-  gem 'erubis'
-  gem 'rake'
+  gem "metadown", git: "https://github.com/steveklabnik/metadown.git"
+  gem "pygments.rb"
+  gem "rake"
+  gem "tomlrb"
 end

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ The repository for proposals for major changes to Chef, Chef Server, and related
 
 Read [RFC000](https://github.com/opscode/chef-rfc/blob/master/rfc000-rfc-process.md#submitting-an-rfc) for more information on how to submit an RFC and get it reviewed.
 
+## Generating HTML Documentation
+
+To turn the Markdown documents into HTML that can be served from a website on
+the gh-pages branch. Git ≥ 2.7, Ruby, and the Bundler gem are required.
+
+You'll need to have the gh-pages branch checked out locally:
+
+    git fetch; git checkout -t origin/gh-pages; git checkout master
+
+Run:
+
+    bundle install; bundle exec rake generate:pages
+
+After that there will be a gh-pages subdirectory that has the generated files
+and is on the gh-pages branch. These can be committed and pushed to deploy the
+website to https://chef.github.io/chef-rfc/.
+
 ## Copyright
 
 Chef RFCs are in the public domain. In jurisdictions that do not allow for this, they are available under CC0. To the extent possible under law, the person who associated CC0 with their work has waived all copyright and related or neighboring rights to their work.

--- a/tasks/pages.rb
+++ b/tasks/pages.rb
@@ -15,17 +15,6 @@ end
 
 POSTAMBLE=<<-EOF.freeze
     </div>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/fastclick/1.0.3/fastclick.min.js"></script>
-    <script src="https://style.chef.io/dist/1.0.1/javascripts/chef.js"></script>
-    <script>
-      $(document).chef({
-        assets: {
-          images: 'https://style.chef.io/assets/images'
-        }
-      });
-    </script>
   </body>
 </html>
 EOF
@@ -37,17 +26,18 @@ PREAMBLE=<<-EOF.freeze
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable = no">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation-essential/6.2.2/css/foundation.min.css">
+    <style>
+      a { color: #f18b21; }
+      a:hover, a:focus { color: #3f5364; }
+    </style>
     <title>Chef RFCs</title>
-    <link href='http://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
-    <link href="/images/favicon.ico" rel="shortcut icon">
-    <script src="https://style.chef.io/dist/0.1.8/javascripts/vendor/modernizr.js"></script>
-    <link rel="stylesheet" href="https://style.chef.io/dist/1.0.1/stylesheets/chef.css">
   </head>
   <body>
-    <div class="container">
+    <div class="row medium-12 columns">
       <header class="clearfix">
         <div class="left">
-          <a href="http://chef.github.io"><h1>Chef RFCs</h1></a>
+          <a href="/chef-rfc"><h1>Chef RFCs</h1></a>
         </div>
       </header>
 EOF


### PR DESCRIPTION
The gh-pages HTML output was previously using Chef Web Core assets
served from https://style.chef.io. These no longer exist, so the page
wasn't loading.

Instead of trying to get Web Core working, This makes it just pull in
the basic Foundation CSS from CDNJS and tweak the colors a bit.

I don't know what the old site looked like or if this looks better or
worse, but I know this one will load faster, since I deleted a bunch of
stuff.

Signed-off-by: Nathan L Smith <smith@chef.io>