### PR TITLE
add support windows for cookbooks and ruby versions

### DIFF
--- a/rfc081-release-cadence.md
+++ b/rfc081-release-cadence.md
@@ -98,6 +98,19 @@ month old Ruby versions -- long after the Ruby community had stopped support.  T
 sliding windows here means that the support windows for Chef and Ruby will be more
 synchronized.
 
+The combined sliding window of Chef Client support of Ruby and cookbook and ecosystem
+support of Chef Client needs to better match the Ruby language support window.  As
+external gem authors tend to drop support of Ruby versions that fall into security-only
+releases, we also plan on dropping support of Ruby versions once they fall into
+security-only releases.  For example, in Q1 of 2016 ruby-2.3.0 had been released,
+ruby 2.2.x was still being maintained and ruby-2.1.x fell into security-only releases,
+which caused many rubygems -- most notably rack-2.0 and activesupport-5.0 to later
+drop support for ruby-2.1.x.  This caused issues everywhere in the Chef ecosystem
+as Chef Client had stayed on ruby-2.1 until it became a crisis, and we were forced
+to work around supporting ruby versions that the rubygems community had dropped
+support for.  The Ruby, Cookbook and Ecosystem support cadence is design specifically
+to avoid this situation.
+
 ## Copyright
 
 This work is in the public domain. In jurisdictions that do not allow for this,

--- a/rfc081-release-cadence.md
+++ b/rfc081-release-cadence.md
@@ -49,7 +49,7 @@ elect to drop support for older chef-client versions.  This window does not rese
 a major version release so that the prior major version track is supported for a 6 month
 window.  Non-Chef managed community cookbooks are encouraged to follow this policy.
 
-As an example, in May we will typically drop 14.1.0 and both 14.0 and 14.1 will be
+As an example, in May we will typically release 14.1.0 and both 14.0 and 14.1 will be
 supported.  The version of 13 release 6 months prior should be 13.8 and will still
 be supported so that 6 versions will be considered current (13.8 through 13.11 plus
 14.0 and 14.1).  At that point community cookbooks may choose to start using 13.8
@@ -57,7 +57,7 @@ features and drop support for versions prior to 13.7
 
 ## Ruby Cadence
 
-Since the ruby language itself releases new minor versions over the Christmas holidays,
+Since the Ruby language itself releases new minor versions over the Christmas holidays,
 the April major release of Chef Client should include the minor revision of ruby which
 landed the prior Christmas.  Combined with the 6 month sliding window for cookbook
 support that also implies that when the prior major release of the client falls off

--- a/rfc081-release-cadence.md
+++ b/rfc081-release-cadence.md
@@ -55,6 +55,13 @@ be supported so that 6 versions will be considered current (13.8 through 13.11 p
 14.0 and 14.1).  At that point community cookbooks may choose to start using 13.8
 features and drop support for versions prior to 13.7
 
+## Rationale
+
+This allows cookbook authors to drop support for old cookbook versions and use new
+features in new client versions.  It gets us out of the situation where cookbooks still
+need to support 28-month old versions of chef client versions and can't use any features
+added in the past 28-months of software development.
+
 ## Ruby Cadence
 
 Since the Ruby language itself releases new minor versions over the Christmas holidays,
@@ -68,6 +75,16 @@ The release of the new major version may be delayed if there are show stopping b
 in the released version of ruby (we assume that 4 months will be enough time for
 major regressions in the core language to be addressed, but that is an external
 dependency).
+
+## Rationale
+
+This also allows cookbook authors and the ecosystem to drop support for old versions of
+the ruby language, which itself only has a useful support window of about 24-months.  When
+we had to support 28-months old chef-client versions that themselves were shipping 12-24
+month old ruby platforms that meant that cookbooks and tooling had to support some 40-52
+month old ruby versions -- long after the ruby community had stopped support.  The combined
+sliding windows here means that the support windows for chef and ruby will be more
+synchronized.
 
 ## Copyright
 

--- a/rfc081-release-cadence.md
+++ b/rfc081-release-cadence.md
@@ -41,7 +41,7 @@ potential hot fixes or follow-up.
 Major releases in April avoids releasing during winter holidays, summer
 vacations, ChefConf and Chef Summits.
 
-## Cookbook Support
+## Cookbook and Ecosystem Tooling Support
 
 The latest version of Chef-managed community cookbooks should support at least the latest 6
 months of Chef Client versions.  After 6 months, Chef-managed community cookbooks may
@@ -54,6 +54,9 @@ supported.  The version of 13 release 6 months prior should be 13.8 and will sti
 be supported so that 6 versions will be considered current (13.8 through 13.11 plus
 14.0 and 14.1).  At that point community cookbooks may choose to start using 13.8
 features and drop support for versions prior to 13.7
+
+Tooling external to cookbooks (cookstyle, chefspec, stove, foodcritic, halite,
+poise-hoist, etc) is similarly encouraged to follow this policy.
 
 ## Rationale
 

--- a/rfc081-release-cadence.md
+++ b/rfc081-release-cadence.md
@@ -44,10 +44,10 @@ vacations, ChefConf and Chef Summits.
 ## Cookbook Support
 
 The latest version of Chef-managed community cookbooks should support at least the latest 6
-months of chef-client versions.  After 6 months, chef managed community cookbooks may
-elect to drop support for older chef-client versions.  This window does not reset on
+months of Chef Client versions.  After 6 months, Chef-managed community cookbooks may
+elect to drop support for older Chef Client versions.  This window does not reset on
 a major version release so that the prior major version track is supported for a 6 month
-window.  Non-Chef managed community cookbooks are encouraged to follow this policy.
+window.  Non-Chef-managed community cookbooks are encouraged to follow this policy.
 
 As an example, in May we will typically release 14.1.0 and both 14.0 and 14.1 will be
 supported.  The version of 13 release 6 months prior should be 13.8 and will still
@@ -59,31 +59,40 @@ features and drop support for versions prior to 13.7
 
 This allows cookbook authors to drop support for old cookbook versions and use new
 features in new client versions.  It gets us out of the situation where cookbooks still
-need to support 28-month old versions of chef client versions and can't use any features
+need to support 28-month old versions of Chef Client versions and can't use any features
 added in the past 28-months of software development.
 
 ## Ruby Cadence
 
 Since the Ruby language itself releases new minor versions over the Christmas holidays,
-the April major release of Chef Client should include the minor revision of ruby which
+the April major release of Chef Client should include the minor revision of Ruby which
 landed the prior Christmas.  Combined with the 6 month sliding window for cookbook
 support that also implies that when the prior major release of the client falls off
-of community cookbook support that the prior minor release of ruby will also fall
+of community cookbook support that the prior minor release of Ruby will also fall
 off of community cookbook support (including the cookstyle gem and related tooling).
 
 The release of the new major version may be delayed if there are show stopping bugs
-in the released version of ruby (we assume that 4 months will be enough time for
+in the released version of Ruby (we assume that 4 months will be enough time for
 major regressions in the core language to be addressed, but that is an external
 dependency).
+
+If the Ruby language version released over Christmas has a show-stopper bug then the
+next major Chef Client version may be released without it.  It can then be included
+in a subsequent minor version bump.  This RFC deliberately uses 'should' instead of
+'must', and [RFC-034](https://github.com/chef/chef-rfc/blob/b7bd9c53bf96235f9334e65bb5848f7843c81fed/rfc034-ruby-193-eol.md#specification)
+allows for a minor version bump of Ruby with a minor version
+bump of Chef Client.  Show stoppers in Ruby itself will not hold up major releases
+of Chef Client, and missing the major release window will not hold up bumping the
+Ruby version.
 
 ## Rationale
 
 This also allows cookbook authors and the ecosystem to drop support for old versions of
-the ruby language, which itself only has a useful support window of about 24-months.  When
-we had to support 28-months old chef-client versions that themselves were shipping 12-24
-month old ruby platforms that meant that cookbooks and tooling had to support some 40-52
-month old ruby versions -- long after the ruby community had stopped support.  The combined
-sliding windows here means that the support windows for chef and ruby will be more
+the Ruby language, which itself only has a useful support window of about 24-months.  When
+we had to support 28-months old Chef Client versions that themselves were shipping 12-24
+month old Ruby platforms that meant that cookbooks and tooling had to support some 40-52
+month old Ruby versions -- long after the Ruby community had stopped support.  The combined
+sliding windows here means that the support windows for Chef and Ruby will be more
 synchronized.
 
 ## Copyright

--- a/rfc081-release-cadence.md
+++ b/rfc081-release-cadence.md
@@ -43,9 +43,11 @@ vacations, ChefConf and Chef Summits.
 
 ## Cookbook Support
 
-The latest version of community cookbooks are required to support only the latest 6
-months of chef-client versions.  This window does not reset on a major version release
-so that the prior major version track is supported for a 6 month window.
+The latest version of Chef-managed community cookbooks should support at least the latest 6
+months of chef-client versions.  After 6 months, chef managed community cookbooks may
+elect to drop support for older chef-client versions.  This window does not reset on
+a major version release so that the prior major version track is supported for a 6 month
+window.  Non-Chef managed community cookbooks are encouraged to follow this policy.
 
 As an example, in May we will typically drop 14.1.0 and both 14.0 and 14.1 will be
 supported.  The version of 13 release 6 months prior should be 13.8 and will still

--- a/rfc081-release-cadence.md
+++ b/rfc081-release-cadence.md
@@ -41,6 +41,32 @@ potential hot fixes or follow-up.
 Major releases in April avoids releasing during winter holidays, summer
 vacations, ChefConf and Chef Summits.
 
+## Cookbook Support
+
+The latest version of community cookbooks are required to support only the latest 6
+months of chef-client versions.  This window does not reset on a major version release
+so that the prior major version track is supported for a 6 month window.
+
+As an example, in May we will typically drop 14.1.0 and both 14.0 and 14.1 will be
+supported.  The version of 13 release 6 months prior should be 13.8 and will still
+be supported so that 6 versions will be considered current (13.8 through 13.11 plus
+14.0 and 14.1).  At that point community cookbooks may choose to start using 13.8
+features and drop support for versions prior to 13.7
+
+## Ruby Cadence
+
+Since the ruby language itself releases new minor versions over the Christmas holidays,
+the April major release of Chef Client should include the minor revision of ruby which
+landed the prior Christmas.  Combined with the 6 month sliding window for cookbook
+support that also implies that when the prior major release of the client falls off
+of community cookbook support that the prior minor release of ruby will also fall
+off of community cookbook support (including the cookstyle gem and related tooling).
+
+The release of the new major version may be delayed if there are show stopping bugs
+in the released version of ruby (we assume that 4 months will be enough time for
+major regressions in the core language to be addressed, but that is an external
+dependency).
+
 ## Copyright
 
 This work is in the public domain. In jurisdictions that do not allow for this,


### PR DESCRIPTION
We want to also establish a cadence for the support windows of ruby and cookbooks.

I felt like it made logical sense to me to put that here.