### PR TITLE
Exclude documentation contributions from DCO

### DIFF
--- a/rfc080-dco.md
+++ b/rfc080-dco.md
@@ -65,6 +65,7 @@ The DCO is an attestation attached to every contribution made by every developer
   * The bot must include instructions for how to edit commits adding a `Signed-off-by` line.
 * A blog post and mailing list announcement will be made before the cutover.
 * This will have *no* impact on [the "obvious fix" rule](https://docs.chef.io/community_contributions.html#the-obvious-fix-rule).  Contributions that meet these criteria will not need a DCO but should include "obvious fix" in the commit message as outlined in [the "obvious fix" policy](https://docs.chef.io/community_contributions.html#the-obvious-fix-rule).
+* DCO sign-off will not be required for contributions to documentation repositories (such as `chef/chef-web-docs`) or contributions that only affect documentation embedded within project repositories (such as the `docs` directory in `chef/inspec`).
 
 ## Copyright
 


### PR DESCRIPTION
Updating RFC 80 to eliminate the DCO requirement for commits
to documentation repositories or docs folders within projects, such
as InSpec.

chef-web-docs is already excluded from requiring DCO as stated on
the docs site (https://docs.chef.io/community_contributions.html#developer-certification-of-origin-dco)
but does not appropriately address docs embedded within a project.
This change makes the expectations clearer and consistent with the
docs.chef.io.

An additional PR to the docs site will be submitted in parallel to
this PR.