### PR TITLE
Withdraw RFC 024

### DIFF
--- a/rfc024-local-mode-default.md
+++ b/rfc024-local-mode-default.md
@@ -2,7 +2,7 @@
 RFC: 24
 Title: Local Mode Default
 Author: John Keiser <jkeiser@getchef.com>
-Status: Accepted
+Status: Withdrawn
 Type: Standards Track
 Chef-Version: 12
 ---


### PR DESCRIPTION
With the revival of `chef-solo` based around Zero mode, I would like to suggest we withdraw RFC 24 and instead make chef-client provide a clearer error message when the server URL isn't set.