### PR TITLE
fix table formatting

### DIFF
--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -32,27 +32,27 @@ supported.
 If not specified, chef works with all versions of a given
 platform that the manufacturer supports.
 
-Platform | Versions | Architectures | Package Format
- ---- | --- | --- | --- | ---		
-AIX | 6.1, 7.1, 7.2 | ppc64 | bff
-CentOS | 5, 6, 7 | i386, x86_64 | rpm
-Cisco IOS XR | 6 | x86_64 | rpm
-Cisco NX-OS | 7 | x86_64 | rpm
-Debian | 7, 8 | i386, x86_64 | deb
-FreeBSD | 9, 10 | i386, amd64 | pkg_add pkg
-Mac OS X | 10.9, 10.10, 10.11 | x86_64 | dmg
-Oracle Enterprise Linux | 5, 6, 7 | i386, x86_64 | rpm
-Red Hat Enterprise Linux | 5, 6, 7 | i386, x86_64 | rpm
-Solaris | 10u11, 11 | sparc, x86 | shar
-Windows | 7, 8, 8.1, 2008, 2008R2, 2012, 2012R2 | x86, x86_64 | msi
-Ubuntu Linux | | x86, x86_64 | deb
-SUSE Linux Enterprise Server  | 11, 12 | x86_64
+Platform | Versions | Architectures | Package Format  
+ --- | --- | --- | ---  
+AIX | 6.1, 7.1, 7.2 | ppc64 | bff  
+CentOS | 5, 6, 7 | i386, x86_64 | rpm  
+Cisco IOS XR | 6 | x86_64 | rpm  
+Cisco NX-OS | 7 | x86_64 | rpm  
+Debian | 7, 8 | i386, x86_64 | deb  
+FreeBSD | 9, 10 | i386, amd64 | pkg_add pkg  
+Mac OS X | 10.9, 10.10, 10.11 | x86_64 | dmg  
+Oracle Enterprise Linux | 5, 6, 7 | i386, x86_64 | rpm  
+Red Hat Enterprise Linux | 5, 6, 7 | i386, x86_64 | rpm  
+Solaris | 10u11, 11 | sparc, x86 | shar  
+Windows | 7, 8, 8.1, 2008, 2008R2, 2012, 2012R2 | x86, x86_64 | msi  
+Ubuntu Linux | | x86, x86_64 | deb  
+SUSE Linux Enterprise Server  | 11, 12 | x86_64  
 Scientific Linux | 5.x, 6.x and 7.x | i386, x86_64		
-Fedora  | | x86_64
-OpenSUSE | 13.1/13.2/42.1 | x86_64
-OmniOS | | x86_64
-Gentoo Linux | | x86_64
-Arch Linux | | x86_64
+Fedora  | | x86_64  
+OpenSUSE | 13.1/13.2/42.1 | x86_64  
+OmniOS | | x86_64  
+Gentoo Linux | | x86_64  
+Arch Linux | | x86_64  
 
 ## Copyright
 


### PR DESCRIPTION
GFM's formatting required particular spacing at the end of the line in order to render the table & an additional "field" at the end of the divider line was mucking things up.