### PR TITLE
Dependency Update Cadence

### DIFF
--- a/new/dependency-update-cadence.md
+++ b/new/dependency-update-cadence.md
@@ -1,0 +1,73 @@
+---
+RFC: unassigned
+Title: Dependency Update Cadence
+Author: Jennifer Davis <sigje@chef.io>
+Status: Draft
+Type: Process
+---
+
+# Dependency Update Cadence
+
+This RFC describes the Ruby, Cookbook and Ecosystem support cadence as an addendum to the [Chef OSS project versioning and release policies.](https://chef.github.io/chef-rfc/rfc086-chef-oss-project-policies.html) and the [cookbook release process](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/RELEASE_PROCESS.MD).
+
+## Motivation
+
+    As a person who writes and shares community cookbooks, 
+    I want to drop old support for old client versions and use new client versions,
+    so that cookbook complexity can be reduced.
+
+    As a person who writes and shares community cookbooks,
+    I want to drop support for old versions of the Ruby language,
+    so that I don't have to support ruby versions that are no longer supported by the ruby community.
+
+    As a person who uses community cookbooks in my own recipes, 
+    I want to know the policy for cookbook support,
+    so I can understand the impact of delaying updating underlying dependencies.
+
+## Specification
+
+### Cookbook and Ecosystem Tooling Support
+
+Chef-managed community cookbooks should support at least the latest 6 months of [Chef Client](https://github.com/chef/chef/blob/master/CHANGELOG.md) versions. After 6 months, Chef-managed community cookbooks may
+elect to drop support for older Chef Client versions. This window does not reset on
+a major version release so that the prior major version track is supported for a 6 month window. Non-Chef-managed community cookbooks are encouraged to follow this policy.
+
+As an example, based on the [Chef OSS project versioning and release policies](https://chef.github.io/chef-rfc/rfc086-chef-oss-project-policies.html), in May if we release Chef Client 14.1.0, both 14.0 and 14.1 will be
+supported.  The version of 13 release 6 months prior should be 13.8 and will still
+be supported so that 6 versions will be considered current (13.8 through 13.11 plus
+14.0 and 14.1).  At that point community cookbooks may choose to start using 13.8
+features and drop support for versions prior to 13.7.
+
+Tooling external to cookbooks (cookstyle, chefspec, stove, foodcritic, halite,
+poise-hoist, etc) is similarly encouraged to follow this policy.
+
+### Ruby Cadence
+
+Since the Ruby language itself releases new minor versions over the Christmas holidays, the April major release of Chef Client should include the minor revision of Ruby which landed the prior Christmas.  Combined with the 6 month sliding window for cookbook support that also implies that when the prior major release of the client falls off of community cookbook support that the prior minor release of Ruby will also fall off of community cookbook support (including the cookstyle gem and related tooling).
+
+The release of the new major version may be delayed if there are show stopping bugs
+in the released version of Ruby. We assume that 4 months will be enough time for
+major regressions in the core language to be addressed, but that is an external
+dependency.
+
+If the Ruby language version released over Christmas has a show-stopper bug then the
+next major Chef Client version may be released without it.  It can then be included
+in a subsequent minor version bump.  This RFC deliberately uses 'should' instead of
+'must', and [RFC-034](https://github.com/chef/chef-rfc/blob/b7bd9c53bf96235f9334e65bb5848f7843c81fed/rfc034-ruby-193-eol.md#specification)
+allows for a minor version bump of Ruby with a minor version
+bump of Chef Client.  Show stoppers in Ruby itself will not hold up major releases
+of Chef Client, and missing the major release window will not hold up bumping the
+Ruby version.
+
+### Operating System Versions
+
+Each cookbook will define supported platforms along with version constraints through the use of the `supports` keyword in the metadata and README files within the cookbook. 
+
+Chef-managed community cookbooks may elect to drop support for platform versions that are no longer supported by the platform maintainers. 
+
+## Copyright
+
+This work is in the public domain. In jurisdictions that do not allow for this,
+this work is available under CC0. To the extent possible under law, the person
+who associated CC0 with this work has waived all copyright and related or
+neighboring rights to this work.

--- a/new/dependency-update-cadence.md
+++ b/new/dependency-update-cadence.md
@@ -1,7 +1,9 @@
 ---
 RFC: unassigned
 Title: Dependency Update Cadence
-Author: Jennifer Davis <sigje@chef.io>
+Author: 
+ - Lamont Granquist <lamont@chef.io> 
+ - Jennifer Davis <sigje@chef.io>
 Status: Draft
 Type: Process
 ---
@@ -28,7 +30,7 @@ This RFC describes the Ruby, Cookbook and Ecosystem support cadence as an addend
 
 ### Cookbook and Ecosystem Tooling Support
 
-Chef-managed community cookbooks should support at least the latest 6 months of [Chef Client](https://github.com/chef/chef/blob/master/CHANGELOG.md) versions. After 6 months, Chef-managed community cookbooks may
+Chef-managed community cookbooks should support at least the last 6 months of [Chef Client](https://github.com/chef/chef/blob/master/CHANGELOG.md) versions. After 6 months, Chef-managed community cookbooks may
 elect to drop support for older Chef Client versions. This window does not reset on
 a major version release so that the prior major version track is supported for a 6 month window. Non-Chef-managed community cookbooks are encouraged to follow this policy.
 
@@ -63,7 +65,7 @@ Ruby version.
 
 Each cookbook will define supported platforms along with version constraints through the use of the `supports` keyword in the metadata and README files within the cookbook. 
 
-Chef-managed community cookbooks may elect to drop support for platform versions that are no longer supported by the platform maintainers. 
+Chef-managed community cookbooks should drop support for platform versions that are no longer supported by the platform maintainers. 
 
 ## Copyright
 


### PR DESCRIPTION
Additional context for this RFC can be found in #249.

From the Rationale sections from the original PR from @lamont-granquist  that also has context:

+This allows cookbook authors to drop support for old cookbook versions and use new
+features in new client versions.  It gets us out of the situation where cookbooks still
+need to support 28-month old versions of Chef Client versions and can't use any features
+added in the past 28-months of software development.

+This also allows cookbook authors and the ecosystem to drop support for old versions of
+the Ruby language, which itself only has a useful support window of about 24-months.  When
+we had to support 28-months old Chef Client versions that themselves were shipping 12-24
+month old Ruby platforms that meant that cookbooks and tooling had to support some 40-52
+month old Ruby versions -- long after the Ruby community had stopped support.  The combined
+sliding windows here means that the support windows for Chef and Ruby will be more
+synchronized.
+
+The combined sliding window of Chef Client support of Ruby and cookbook and ecosystem
+support of Chef Client needs to better match the Ruby language support window.  As
+external gem authors tend to drop support of Ruby versions that fall into security-only
+releases, we also plan on dropping support of Ruby versions once they fall into
+security-only releases.  For example, in Q1 of 2016 ruby-2.3.0 had been released,
+ruby 2.2.x was still being maintained and ruby-2.1.x fell into security-only releases,
+which caused many rubygems -- most notably rack-2.0 and activesupport-5.0 to later
+drop support for ruby-2.1.x.  This caused issues everywhere in the Chef ecosystem
+as Chef Client had stayed on ruby-2.1 until it became a crisis, and we were forced
+to work around supporting ruby versions that the rubygems community had dropped
+support for.  The Ruby, Cookbook and Ecosystem support cadence is design specifically
+to avoid this situation.

