### PR TITLE
Provide many levels of debug logs

### DIFF
--- a/new/debug_levels.md
+++ b/new/debug_levels.md
@@ -1,0 +1,53 @@
+---
+RFC: unassigned
+Title: Improved Log Levels
+Author: Thom May <thom@chef.io>
+Status: Draft
+Type: Standards Track
+---
+
+# Improved Log Levels
+
+Presently, the only way to debug a failing chef run is to enable debug
+logging, which is intended more for the maintainers of Chef than for a
+systems engineer. We would like to introduce several levels of enhanced
+logging, enabling more appropriate output for various roles.
+
+## Motivation
+
+    As a Chef maintainer,
+    I want to know exactly what chef is doing,
+    so that I can maintain and develop chef.
+
+    As a cookbook author,
+    I want to ensure that my cookbook is interacting with the system as
+    I expect,
+    so that I can write cookbooks efficiently.
+
+    As a systems engineer,
+    I want to see the output of running commands,
+    so that I can debug chef failures.
+
+## Specification
+
+We propose the addition of a number of addition log levels. `debug`
+level, since it is widely documented and used, would become the level
+appropriate for users of Chef to gain better understanding of why a chef
+client run is failing. This would include the output from system
+commands, ohai timing data, and some details from exceptions.
+`author` log level would include all `debug` output, as well as full
+details from exceptions.
+`maintainer` log level would include all of the above, as well as full
+output from Ohai plugins, debug logging of HTTP requests, and so on.
+
+## Downstream Impact
+
+Any libraries that Chef includes (such as Ohai, mixlib-authentication
+and so on) would need to be updated to use appropriate log levels.
+
+## Copyright
+
+This work is in the public domain. In jurisdictions that do not allow for this,
+this work is available under CC0. To the extent possible under law, the person
+who associated CC0 with this work has waived all copyright and related or
+neighboring rights to this work.

--- a/new/debug_levels.md
+++ b/new/debug_levels.md
@@ -10,8 +10,8 @@ Type: Standards Track
 
 Presently, the only way to debug a failing chef run is to enable debug
 logging, which is intended more for the maintainers of Chef than for a
-systems engineer. We would like to introduce several levels of enhanced
-logging, enabling more appropriate output for various roles.
+systems engineer. We would like to move to a structured metadata model
+that allows us to slice and dice log messages.
 
 ## Motivation
 
@@ -30,20 +30,18 @@ logging, enabling more appropriate output for various roles.
 
 ## Specification
 
-We propose the addition of a number of addition log levels. `debug`
-level, since it is widely documented and used, would become the level
-appropriate for users of Chef to gain better understanding of why a chef
-client run is failing. This would include the output from system
-commands, ohai timing data, and some details from exceptions.
-`author` log level would include all `debug` output, as well as full
-details from exceptions.
-`maintainer` log level would include all of the above, as well as full
-output from Ohai plugins, debug logging of HTTP requests, and so on.
+We propose to move the chef client, and related libraries, to a
+structured logging format. This would allow us to tag individual log
+messages with extended metadata, such as the resource/subsystem, the
+cookbook we're running in, the log level and so on.
+We would then update the logging commands to allow the user to specify a
+set of tags that they're interested in, allowing a user to only get log
+output from the resources associated with a single cookbook.
 
 ## Downstream Impact
 
 Any libraries that Chef includes (such as Ohai, mixlib-authentication
-and so on) would need to be updated to use appropriate log levels.
+and so on) would need to be updated to use structured logging.
 
 ## Copyright
 

--- a/rfc096-improved-log-levels.md
+++ b/rfc096-improved-log-levels.md
@@ -1,8 +1,8 @@
 ---
-RFC: unassigned
+RFC: 96
 Title: Improved Log Levels
 Author: Thom May <thom@chef.io>
-Status: Draft
+Status: Accepted
 Type: Standards Track
 ---
 
@@ -34,6 +34,7 @@ We propose to move the chef client, and related libraries, to a
 structured logging format. This would allow us to tag individual log
 messages with extended metadata, such as the resource/subsystem, the
 cookbook we're running in, the log level and so on.
+
 We would then update the logging commands to allow the user to specify a
 set of tags that they're interested in, allowing a user to only get log
 output from the resources associated with a single cookbook.


### PR DESCRIPTION
In general, the logging one needs to debug a failing chef run is very different to the logging one needs to debug a problem in chef's code.
We should make it so they are two separate things.