### PR TITLE
Add Socrata to the reserved Supermarket prefixes

### DIFF
--- a/rfc078-supermarket-prefix.md
+++ b/rfc078-supermarket-prefix.md
@@ -66,7 +66,8 @@ your prefix and the person or organization that will be responsible for it.
 * `poise` - [coderanger](https://github.com/coderanger)
 * `sbp` - [Schuberg Philis](https://github.com/sbp-cookbooks)
 * `sc` - [Sous Chefs](https://github.com/sous-chefs)
-* `sigsci` - [signalsciences] (https://github.com/signalsciences)
+* `sigsci` - [signalsciences](https://github.com/signalsciences)
+* `snu` - [Socrata](https://github.com/socrata-cookbooks)
 
 ## Copyright
 


### PR DESCRIPTION
We're making an effort to open source more of our cookbooks and naming things is hard, especially when the most obvious name is taken.

There is currently one cookbook with this prefix ([snu-sumologic](https://supermarket.chef.io/cookbooks/snu-sumologic)) and it's one of ours.

Signed-off-by: Jonathan Hartman <j@hartman.io>