### PR TITLE
disable session and passwd

### DIFF
--- a/new/disable_passwd_and_sessions_plugins.md
+++ b/new/disable_passwd_and_sessions_plugins.md
@@ -1,0 +1,37 @@
+---
+RFC: unassigned
+Title: Disable Passwd and Sessions Ohai plugins
+Author: Thom May <thom@chef.io>
+Status: Draft
+Type: Informational
+---
+
+# Disable the Passwd and Sessions Ohai plugins
+
+We get a large number of user reports that these two plugins can cause a
+huge amount of unwanted storage use, especially in large enterprises
+with nodes hooked up to an AD tree. We should disable them by default
+in Chef 14, and provide appropriate notifications.
+
+## Motivation
+
+    As an Operations Engineer,
+    I want to run my Chef Server efficiently,
+    so that I can concentrate on providing value to my employers.
+
+## Specification
+
+By default, make the `passwd` and `sessions` plugins disabled by
+default.
+
+## Downstream Impact
+
+Any cookbooks that require these plugins will need to ensure that they
+document this, and operators will need to re-enable them.
+
+## Copyright
+
+This work is in the public domain. In jurisdictions that do not allow for this,
+this work is available under CC0. To the extent possible under law, the person
+who associated CC0 with this work has waived all copyright and related or
+neighboring rights to this work.

--- a/rfc103-disable-passwd-and-sessions-plugins.md
+++ b/rfc103-disable-passwd-and-sessions-plugins.md
@@ -1,8 +1,8 @@
 ---
-RFC: unassigned
+RFC: 103
 Title: Disable Passwd and Sessions Ohai plugins
 Author: Thom May <thom@chef.io>
-Status: Draft
+Status: Accepted
 Type: Informational
 ---
 


### PR DESCRIPTION
We get so many reports of failed chef run reports, or huge use of disk space as a result of these two plugins. Let's turn them off by default.

An alternative approach might be to add them to the `automatic_attribute_blacklist`, but I think the UX of understanding that and how users would go about managing the blacklist would be much worse.