### PR TITLE
expose automatic chef_environment attr

### DIFF
--- a/new/chef_env_attribute.md
+++ b/new/chef_env_attribute.md
@@ -1,16 +1,16 @@
 ---
 RFC: unassigned
-Title: `chef_environment` as an attribute
+Title: Expose more settings as attributes
 Author: Thom May <thom@chef.io>
 Status: Draft
 Type: Standards Track
 ---
 
-# Exposing the chef\_environment attribute
+# Exposing some core settings as attributes
 
-Historically we've not exposed the Chef environment as an automatic
-attribute, although tools such as poise-hoist have changed that. Policy
-groups make the whole situation a little more murky.
+There are a number of settings, such as the node name and the environment, that we've historically not exposed as automatic attributes.
+The environment attribute is a bit more complicated in the world of
+policy groups, and this RFC clarifies that situation too
 
 ## Motivation
 
@@ -20,16 +20,18 @@ groups make the whole situation a little more murky.
 
 ## Specification
 
+We will expose the automatic attribute `name`, reflecting the name of
+the node.
+
 We will expose the automatic attribute `chef_environment`. In non-policy
 setups, the attribute will expose the environment that the node is in.
 
 In policy setups, it will expose the name of the policy group the node
-is in. We will also ensure that `node.chef_environment` returns the same data.
+is in. We will also ensure that `node.chef_environment` returns the same data. We'll also expose `policy_group` and `policy_name`, to go along with `policy_revision`.
 
 ## Downstream Impact
 
-Cookbooks will have easy access to see which environment they're running
-in.
+Cookbooks will have easy access to more attributes.
 
 ## Copyright
 

--- a/new/chef_env_attribute.md
+++ b/new/chef_env_attribute.md
@@ -1,0 +1,38 @@
+---
+RFC: unassigned
+Title: `chef_environment` as an attribute
+Author: Thom May <thom@chef.io>
+Status: Draft
+Type: Standards Track
+---
+
+# Exposing the chef\_environment attribute
+
+Historically we've not exposed the Chef environment as an automatic
+attribute, although tools such as poise-hoist have changed that. Policy
+groups make the whole situation a little more murky.
+
+## Motivation
+
+    As a system engineer,
+    I want to make decisions based on the environment or policy group of a node,
+    so that I get correct behaviour in my cookbooks.
+
+## Specification
+
+We will expose the automatic attribute `chef_environment`. In non-policy
+setups, the attribute will expose the environment that the node is in.
+In policy setups, it will expose the name of the policy group the node
+is in. 
+
+## Downstream Impact
+
+Cookbooks will have easy access to see which environment they're running
+in.
+
+## Copyright
+
+This work is in the public domain. In jurisdictions that do not allow for this,
+this work is available under CC0. To the extent possible under law, the person
+who associated CC0 with this work has waived all copyright and related or
+neighboring rights to this work.

--- a/new/chef_env_attribute.md
+++ b/new/chef_env_attribute.md
@@ -22,8 +22,9 @@ groups make the whole situation a little more murky.
 
 We will expose the automatic attribute `chef_environment`. In non-policy
 setups, the attribute will expose the environment that the node is in.
+
 In policy setups, it will expose the name of the policy group the node
-is in. 
+is in. We will also ensure that `node.chef_environment` returns the same data.
 
 ## Downstream Impact
 

--- a/rfc106-chef_env_attribute.md
+++ b/rfc106-chef_env_attribute.md
@@ -1,8 +1,8 @@
 ---
-RFC: unassigned
+RFC: 106
 Title: Expose more settings as attributes
 Author: Thom May <thom@chef.io>
-Status: Draft
+Status: Accepted
 Type: Standards Track
 ---
 


### PR DESCRIPTION
We should've done this ages ago, but let's get it done.
This is also important should we wish to integrate hoist
directly in to chef.