### PR TITLE
Resources can only be added at new major releases

### DIFF
--- a/rfc100-resource-lifecycle.md
+++ b/rfc100-resource-lifecycle.md
@@ -86,7 +86,7 @@ Factors that influence and inform the decision to deprecate a resource include:
 * Any proposed changes to the interfaces must be implemented in the cookbook prior to adoption.
   * If there are fundamental issues with the resource whether due to naming standards or interface implementation, a new cookbook should be created implementing the resource as intended.
 * Any bugs discovered must be repaired in the cookbook and released prior to adoption.
-* Resource is added to core chef and documentation is updated.
+* During the next major release cycle, the resource is added to core chef and documentation is updated.
 * Add deprecated cookbook warnings for conflicting cookbooks.
 
 ### Process for deprecating resources


### PR DESCRIPTION
We hear repeatedly from our users that adding resources is a breaking change for them. Therefore, we should only do so when appropriate, which is at the time of a yearly major release.
Let's unpack why adding resources is a breaking change:

 * If a user has not updated their copy of the resource cookbook
 * If a user has changed their copy of the resource cookbook

In both cases, the version of the resource in the chef client is the one that will be selected, rather than the one in the user's cookbook. This means that a routine upgrade has the potential to change behaviour that the user relies upon, forcing them to either perform unscheduled work, or, more likely, simply not upgrade their chef client (or worse have to do an emergency downgrade).

This is the most pressing reason to only add new resources once a year.

On top of that, this RFC already specifies that resources must be available and finalised in cookbooks before they're adopted in to core chef; thus this does not impede adoption if a user needs to use the resource.

Additionally, it is much easier to reason about the availability of a resource if one says "This resource is in Chef 14" rather than "this is in 14.1.103".