### PR TITLE
The Future of Chef Workstation

### DIFF
--- a/new/chef-workstation.md
+++ b/new/chef-workstation.md
@@ -1,7 +1,9 @@
 ---
 RFC: unassigned
 Title: The Future of Chef Workstation
-Author: Noah Kantrowitz <noah@coderanger.net>
+Author:
+- Jon Morrow <jmorrow@chef.io>
+- Noah Kantrowitz <noah@coderanger.net>
 Status: Draft
 Type: Informational
 ---
@@ -27,66 +29,76 @@ lack of certainty about which should be used.
 
 ## Specification
 
-Addressing the issues in reverse order:
+1. The `chef-run` command will be renamed to `chef-target` [ed: not attached to this name, suggest a better on in comments].
+2. The `chef-target` gem will be split into its own repository for future development.
+3. The installer currently called "ChefDK" will be renamed "Chef Workstation".
+   This will require setting up documentation to explain the rename, as well as
+   redirects and supporting pages in the download system to ensure users don't
+   get lost.
+4. The `chef-dk` gem will not be renamed at this time, as few users see the gem
+   name there and we're already changing a lot of things. This may be revisited
+   in the future when the dust settles.
+5. The installer for `chef-dk` (now named "Chef Workstation") will be reconfigured
+   to install into `/opt/chef-workstation` and use `~/.chef-workstation` as the
+   primary configuration folder. A symlink for `/opt/chef-dk` (and related windows-y paths)
+   should be added to ensure any scripts that hardcode paths like `/opt/chefdk/bin/chef`
+   continue to function (until such time as we decide to remove them as compatbility layers).
+   Gems in `~/.chefdk/gems` should be added to the gems path, and config files in
+   `~/.chefdk` should work if no file in `~/.chef-workstation` takes priority.
+6. Add the `chef-target` gem to the Chef Workstation installer.
+7. A command stub will be added to the `chef-dk` command processor called `target` [ed: or whatever we call it],
+   which will dispatch to the `chef-target` command. The Chef Workstation installer
+   will map `chef-target` into `embedded/bin/` rather than `bin/` so for most users,
+   this will be the UX.
 
-While the phrasing of "Chef Workstation" is probably better than "ChefDK", the
-difference is not sufficient to warrant such a massive community pivot given
-how long the ChefDK name has been in use and the fact that it doesn't seem to
-be a major source of confusion (at least not in a way that would be solved by
-"Chef Workstation"). As such the Chef Workstation installer will be discontinued
-in favor of ChefDK.
-
-In order to both reduce the naming collision and better integrate the tool with
-the existing ChefDK CLI experience, the `chef-run` command will be moved to be
-a subcommand of the `chef` CLI (a part of the `chef-dk` gem) named `chef target`.
-
-The actual implementation of the `chef target` command could still be in its own
-gem (name undetermined) if that is useful to the development team to improve the
-agility of releases.
+Additionally, while it is out of scope for this RFC, the authors strongly encourage
+future RFCs and discussions about adding additional tools to Chef Workstation/DK
+that are of value to the Chef community.
 
 ## Alternatives
 
-### Keeping the "Chef Workstation" Name
+### Keeping the "ChefDK" Name
 
-If the improved clarity of purpose of the "Chef Workstation" package name is
-something we want to keep, an alternate path would be to do the same `chef-run`
-to `chef target` switch but then rename the ChefDK installers to Chef Workstation.
-This presents significant switching costs to the community in the form of "what
-happened to ChefDK?" and general confusion about the rename, given that ChefDK
-has been used as a name for quite a long time now. But this could be overcome
-with sufficient documentation and redirects of existing ChefDK-related pages.
+While "Chef Workstation" is a clearer name, there is broad community usage and
+understanding of the ChefDK name and brand. We could do a similar process to the
+above, but leave the installed called ChefDK in the end. This would vastly
+simplify the process as we could skip all the compatibility gunk. This would
+just be adding a new tool to ChefDK, as we have done many times before.
 
-In either case, the actual software in the installer is the same, the question
-is is the improved branding of "Chef Workstation" worth the hit to users as we
-switch over and people learn the new term.
+The downside is that there is some pushback against the "Developer Kit" part of
+ChefDK from people that feel the "developer" label is exclusionary or at least
+presents a barrier to the new user experience.
 
-If we go this route, we'll need to work out an upgrade strategy for existing
-ChefDK users who may have `/opt/chefdk` paths in scripts and `~/.chefdk`
-for installed secondary gems. This would likely involve a symlink from `/opt/chefdk`
-to the new `/opt` folder for a while (though eventually it would have to get cleaned
-up so this only delays migration pain for some). Gem installs would have to
-migrated from a user context, possibly with a provided script or `chef` CLI
-command.
+### Making a Dedicated Chef-Target Installer
 
-### Use "Chef Workstation" as a Different Brand
+Rather than including `chef-target` in the DK/Workstation installer, we could
+move it to a focused installer just for the one tool, similar to the InSpec
+installer. This would give the team more agility as they would have much more
+freedom in shaping the UI and UX of this new workflow.
 
-My understanding (which is very incomplete) is part of the initial reason to
-split `chef-run` to its own command was, in part, concern about the growing sprawl of
-commands in the `chef` CLI which could be a speedbump for new users.
+The downside is that this would split the new workflow off from the rest of the
+Chef community, possibly creating friction for users experimenting with new workflows
+for the first time or switching from an existing workflow.
 
-Another option is to leave both "ChefDK" and "Chef Workstation" as active brands,
-with ChefDK continuing as it is today while Chef Workstation becomes a focused,
-single-workflow installer (i.e. remove Berkshelf and other tools not part of the
-`chef-run` workflow) from it. This could mirror the focused installers built by
-the InSpec team.
+### Using "Chef Workstation" as Its Own Brand
 
-I feel like the very near overlap of ChefDK and Chef Workstation in this universe
-would result in long-term user confusion though.
+In this path, we would still add `chef-target` to ChefDK, but we wouldn't
+rename the installer. Instead, "Chef Workstation" would become a new thing,
+explicitly aimed at being a cross-product-line workstation experience, while
+ChefDK stays focused on the Chef (the project) experience.
+
+The downside here is the limitations of human language (more or less). Because
+Chef Software and Chef (the project) have such overlapping names, it would be
+very difficult to explain how these are two different things in the long term,
+likely resulting in user confusion and frustration.
 
 ## Downstream Impact
 
-All current users of the beta Chef Workstation installer would have to eventually
-remove it and install ChefDK to get future updates.
+All current users of ChefDK would need to upgrade to Chef Workstation, though
+this upgrade should be transparent.
+
+Any users of the current beta Chef Workstation installer would also need to
+switch over, though that would not be a transparent upgrade process.
 
 ## Copyright
 

--- a/new/chef-workstation.md
+++ b/new/chef-workstation.md
@@ -1,0 +1,96 @@
+---
+RFC: unassigned
+Title: The Future of Chef Workstation
+Author: Noah Kantrowitz <noah@coderanger.net>
+Status: Draft
+Type: Informational
+---
+
+# The Future of Chef Workstation
+
+ChefConf 2018 saw the unveiling of both the `chef-run` command and a Chef Workstation
+installer package containing it. This has lead to user confusion on two fronts.
+First, the term "Chef run" (or "Chef client run") is already in very common use
+in our community, so trying to communicate about `chef-run` has been tricky.
+Second, having two installers (Chef Workstation and ChefDK) has resulted in a
+lack of certainty about which should be used.
+
+## Motivation
+
+    As a Chef user,
+    I want to use the new Chef functionality,
+    so that I can manage machines/resources without Chef Server.
+
+    As a Chef community member,
+    I want to communicate with other Chef community members,
+    so that I can share knowledge and answer questions.
+
+## Specification
+
+Addressing the issues in reverse order:
+
+While the phrasing of "Chef Workstation" is probably better than "ChefDK", the
+difference is not sufficient to warrant such a massive community pivot given
+how long the ChefDK name has been in use and the fact that it doesn't seem to
+be a major source of confusion (at least not in a way that would be solved by
+"Chef Workstation"). As such the Chef Workstation installer will be discontinued
+in favor of ChefDK.
+
+In order to both reduce the naming collision and better integrate the tool with
+the existing ChefDK CLI experience, the `chef-run` command will be moved to be
+a subcommand of the `chef` CLI (a part of the `chef-dk` gem) named `chef target`.
+
+The actual implementation of the `chef target` command could still be in its own
+gem (name undetermined) if that is useful to the development team to improve the
+agility of releases.
+
+## Alternatives
+
+### Keeping the "Chef Workstation" Name
+
+If the improved clarity of purpose of the "Chef Workstation" package name is
+something we want to keep, an alternate path would be to do the same `chef-run`
+to `chef target` switch but then rename the ChefDK installers to Chef Workstation.
+This presents significant switching costs to the community in the form of "what
+happened to ChefDK?" and general confusion about the rename, given that ChefDK
+has been used as a name for quite a long time now. But this could be overcome
+with sufficient documentation and redirects of existing ChefDK-related pages.
+
+In either case, the actual software in the installer is the same, the question
+is is the improved branding of "Chef Workstation" worth the hit to users as we
+switch over and people learn the new term.
+
+If we go this route, we'll need to work out an upgrade strategy for existing
+ChefDK users who may have `/opt/chefdk` paths in scripts and `~/.chefdk`
+for installed secondary gems. This would likely involve a symlink from `/opt/chefdk`
+to the new `/opt` folder for a while (though eventually it would have to get cleaned
+up so this only delays migration pain for some). Gem installs would have to
+migrated from a user context, possibly with a provided script or `chef` CLI
+command.
+
+### Use "Chef Workstation" as a Different Brand
+
+My understanding (which is very incomplete) is part of the initial reason to
+split `chef-run` to its own command was, in part, concern about the growing sprawl of
+commands in the `chef` CLI which could be a speedbump for new users.
+
+Another option is to leave both "ChefDK" and "Chef Workstation" as active brands,
+with ChefDK continuing as it is today while Chef Workstation becomes a focused,
+single-workflow installer (i.e. remove Berkshelf and other tools not part of the
+`chef-run` workflow) from it. This could mirror the focused installers built by
+the InSpec team.
+
+I feel like the very near overlap of ChefDK and Chef Workstation in this universe
+would result in long-term user confusion though.
+
+## Downstream Impact
+
+All current users of the beta Chef Workstation installer would have to eventually
+remove it and install ChefDK to get future updates.
+
+## Copyright
+
+This work is in the public domain. In jurisdictions that do not allow for this,
+this work is available under CC0. To the extent possible under law, the person
+who associated CC0 with this work has waived all copyright and related or
+neighboring rights to this work.

--- a/new/chef-workstation.md
+++ b/new/chef-workstation.md
@@ -29,31 +29,54 @@ lack of certainty about which should be used.
 
 ## Specification
 
-1. The `chef-run` command will be renamed to `chef-target` [ed: not attached to this name, suggest a better on in comments].
-2. The `chef-target` gem will be split into its own repository for future development.
-3. The installer currently called "ChefDK" will be renamed "Chef Workstation".
+1. The current `chef-apply` command will be deprecated. The use cases around
+   debugging single recipes will be folded into the `chef-shell` tool as `chef-shell --apply`.
+   The simplified local execution use cases for `chef-apply` will be folded into
+   `chef-run`.
+2. The `chef-run` command will be left as-is for now. At some point after Chef 15
+   is released, it will likely be renamed to `chef-apply` once the soon-to-be-deprecated
+   command of the same name is removed. The gem containing the `chef-run` command
+   will be renamed `chef-apply`.
+3. The `chef-run` gem may be split into its own repository for future development,
+   at the discretion of the team working on it.
+4. The installer currently called "ChefDK" will be renamed "Chef Workstation".
    This will require setting up documentation to explain the rename, as well as
    redirects and supporting pages in the download system to ensure users don't
    get lost.
-4. The `chef-dk` gem will not be renamed at this time, as few users see the gem
+5. The `chef-dk` gem will not be renamed at this time, as few users see the gem
    name there and we're already changing a lot of things. This may be revisited
    in the future when the dust settles.
-5. The installer for `chef-dk` (now named "Chef Workstation") will be reconfigured
+6. The Omnibus build configuration files and mega-Gemfile/lock will be moved from
+   the `chef-dk` repository to the `chef-workstation` repository (with all the
+   related build job updates that entails). Going forward the `chef-dk` gem/repo
+   will "own" the `chef` CLI tool and the `chef-workstation` repo will down the
+   build process for the installer.
+7. The installer for `chef-dk` (now named "Chef Workstation") will be reconfigured
    to install into `/opt/chef-workstation` and use `~/.chef-workstation` as the
    primary configuration folder. A symlink for `/opt/chef-dk` (and related windows-y paths)
    should be added to ensure any scripts that hardcode paths like `/opt/chefdk/bin/chef`
    continue to function (until such time as we decide to remove them as compatbility layers).
    Gems in `~/.chefdk/gems` should be added to the gems path, and config files in
    `~/.chefdk` should work if no file in `~/.chef-workstation` takes priority.
-6. Add the `chef-target` gem to the Chef Workstation installer.
-7. A command stub will be added to the `chef-dk` command processor called `target` [ed: or whatever we call it],
-   which will dispatch to the `chef-target` command. The Chef Workstation installer
-   will map `chef-target` into `embedded/bin/` rather than `bin/` so for most users,
-   this will be the UX.
+8. Add the `chef-apply` gem to the Chef Workstation installer.
+9. A command stub will be added to the `chef-dk` command processor called `apply`,
+   which will dispatch to the `chef-run`/`chef-apply` command. The Chef Workstation installer
+   will map `chef-run` (and later `chef-apply`) into `embedded/bin/` rather than
+   `bin/`. This means that most users will remain unaware of the `chef-run`/`chef-apply` CLI,
+   all documentation will use the `chef apply` command line form. The `chef-run`/`chef-apply`
+   CLI will remain for bleeding edge testers or other complex/advanced use cases.
 
 Additionally, while it is out of scope for this RFC, the authors strongly encourage
 future RFCs and discussions about adding additional tools to Chef Workstation/DK
 that are of value to the Chef community.
+
+## Downsides
+
+This does introduce some potential confusion around the "chef apply"/`chef-apply`
+conceptual space. The existing `chef-apply` command line tool has been useful
+for the very early stages of teaching Chef and for some types of debugging, but
+after those early days, it's mostly ignored. As such, the authors of the RFC feel
+this is an acceptable trade off to make.
 
 ## Alternatives
 
@@ -69,9 +92,9 @@ The downside is that there is some pushback against the "Developer Kit" part of
 ChefDK from people that feel the "developer" label is exclusionary or at least
 presents a barrier to the new user experience.
 
-### Making a Dedicated Chef-Target Installer
+### Making a Dedicated Chef-Apply Installer
 
-Rather than including `chef-target` in the DK/Workstation installer, we could
+Rather than including `chef apply` in the DK/Workstation installer, we could
 move it to a focused installer just for the one tool, similar to the InSpec
 installer. This would give the team more agility as they would have much more
 freedom in shaping the UI and UX of this new workflow.
@@ -82,7 +105,7 @@ for the first time or switching from an existing workflow.
 
 ### Using "Chef Workstation" as Its Own Brand
 
-In this path, we would still add `chef-target` to ChefDK, but we wouldn't
+In this path, we would still add `chef apply` to ChefDK, but we wouldn't
 rename the installer. Instead, "Chef Workstation" would become a new thing,
 explicitly aimed at being a cross-product-line workstation experience, while
 ChefDK stays focused on the Chef (the project) experience.


### PR DESCRIPTION
I want to start off by congratulating the Workstation team for launching an awesome new tool. It's an absolutely critical step towards improving our new user experience and I look forward to seeing it develop in the coming months.

In the week or two since ChefConf, there has been much discussion about where the new `chef-run` tool should live in the greater Chef ecosystem. This RFC addresses this question with two main parts:
* the `chef-run` tool will be renamed (currently to `chef-target` but we don't love that name so suggest better ones below)
* ChefDK as a whole will be renamed to "Chef Workstation"

Speaking personally: I'm not 100% sold on this rename. I think it's going to take a good bit of development time and resources to make the upgrade path smooth that could be spent elsewhere to greater effect. I think we as a community may over focus "silver bullet" solutions when the underlying problem with both our new user experience and CLI experience is many years of organic tool growth and minimal tech debt paydown. That said, the name does seem better so even if it's not the best ROI, it's still moving in a good direction, if only a small step.

This RFC will affect almost all of our community, so even if you're never participated in the Chef RFC process before, I encourage you to drop a comment on here with your thoughts or feelings. We value the input of every community member, no matter how active or well-known.