### PR TITLE
Update RFC-21: Chef Platform Support Policy

### DIFF
--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -12,6 +12,13 @@ The purpose of this RFC is to clarify which platforms the Chef community chooses
 
 The [chef docs site](https://docs.chef.io/) has [details of the platforms Chef Software, Inc validates for release](https://docs.chef.io/platforms.html).
 
+# Types of Support
+
+This RFC outlines the process for community support of a platforms on Chef, but it's worth noting the distinction between community supported and Chef Software Inc. supported:
+
+- Commercial Support consists of the platforms that are supported as part of a paid commercial support contract with Chef Software Inc. For a complete list of commercially supported platforms see the [Chef Platform Support Docs ](https://docs.chef.io/platforms.html).
+- Community Support is made up of platforms for which support is only available through the Chef community on a best effort basis.
+
 # Adding a new platform
 
 Community maintenance of a platform requires that core chef resources,

--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -56,6 +56,28 @@ Platform | Architectures | Package Format
  Ubuntu Linux | x86, x86_64 | deb
  Windows | x86, x86_64 | msi
 
+# Platform Support EOL Policy
+
+The Chef community will support a given platform version until the vendor's EOL
+date for that platform version. Because different vendors use different
+terminology, the following table clarifies when Chef products are end-of-life
+according to those vendors’ terms:
+
+Platform | Vendor End of Life
+---- | ---
+AIX | IBM End of Support Date
+Debian | End of maintenance updates
+Enterprise Linux (covers RedHat Enterprise Linux, CentOS) | End of Production 3
+Fedora | End of Life
+FreeBSD | End of Life
+Microsoft Windows | End of Extended Support
+openSUSE | End of Life
+Oracle Enterprise Linux | Premier Support Ends
+Oracle Solaris | Premier Support Ends
+SUSE Linux Enterprise Server | General Support Ends
+Ubuntu Linux | End of maintenance updates
+
+
 ## Copyright
 
 This work is in the public domain. In jurisdictions that do not allow for this, this work is available under CC0. To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.

--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -29,30 +29,25 @@ supported.
 
 # Currently supported platforms
 
-If not specified, chef works with all versions of a given
-platform that the manufacturer supports.
-
-Platform | Versions | Architectures | Package Format
- ---- | --- | --- | --- 	
-AIX | 6.1, 7.1, 7.2 | ppc64 | bff
-CentOS | 5, 6, 7 | i386, x86_64 | rpm
-Cisco IOS XR | 6 | x86_64 | rpm
-Cisco NX-OS | 7 | x86_64 | rpm
-Debian | 7, 8 | i386, x86_64 | deb
-FreeBSD | 9, 10 | i386, amd64 | pkg_add pkg
-Mac OS X | 10.9, 10.10, 10.11, 10.12 | x86_64 | dmg
-Oracle Enterprise Linux | 5, 6, 7 | i386, x86_64 | rpm
-Red Hat Enterprise Linux | 5, 6, 7 | i386, x86_64 | rpm
-Solaris | 10u11, 11 | sparc, x86 | shar
-Windows | 7, 8, 8.1, 2008R2, 2012, 2012R2 | x86, x86_64 | msi
-Ubuntu Linux | | x86, x86_64 | deb
-SUSE Linux Enterprise Server  | 11, 12 | x86_64
-Scientific Linux | 5.x, 6.x and 7.x | i386, x86_64		
-Fedora  | | x86_64 | 
-OpenSUSE | | x86_64 | 
-OmniOS | | x86_64 | 
-Gentoo Linux | | x86_64 |
-Arch Linux | | x86_64 |
+Platform | Architectures | Package Format
+ ---- | --- | ---
+ AIX  | ppc64 | bff
+ Arch Linux | x86_64 | pacman
+ CentOS | i386, x86_64 | rpm
+ Debian | i386, x86_64 | deb
+ Fedora  | x86_64 | rpm
+ FreeBSD  | i386, amd64 | pkg
+ Gentoo Linux | x86_64 |
+ macOS | x86_64 | dmg
+ OmniOS | x86_64 | ips
+ OpenSUSE | x86_64 | rpm
+ Oracle Enterprise Linux | i386, x86_64 | rpm
+ Red Hat Enterprise Linux | x86_64, s390x, ppc64le (7.x), ppc64 (7.x) | rpm
+ Scientific Linux | i386, x86_64	| rpm
+ Solaris | sparc, x86 | shar
+ SUSE Linux Enterprise Server  | x86_64, s390x, ppc64le, ppc64 | rpm
+ Ubuntu Linux | x86, x86_64 | deb
+ Windows | x86, x86_64 | msi
 
 ## Copyright
 

--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -24,8 +24,8 @@ This RFC outlines the process for community support of a platforms on Chef, but 
 Community maintenance of a platform requires that core chef resources,
 including `package`, `file`, and `service`, MUST have working providers
 for the platform. For example, on Debian the package provider supports both
-`dpkg` and `apt`. Ohai SHOULD also be able to gather relevant
-information on the platform.
+`dpkg` and `apt`. Ohai MUST also be able to gather relevant information on
+the platform such as platform information, cpu type/count, and available memory.
 
 In addition to support in code, there SHOULD be a Lieutenant for the
 platform, per RFC 30. There MAY also be one or more Maintainers for the

--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -1,6 +1,6 @@
 ---
 RFC: 21
-Author: Julian Dunn <jdunn@chef.io>
+Author: Julian Dunn <jdunn@chef.io>, Tim Smith <tsmith@chef.io>
 Title: Chef Platform Support Policy
 Status: Accepted
 Type: Informational

--- a/rfc021-platform-support-policy.md
+++ b/rfc021-platform-support-policy.md
@@ -10,51 +10,29 @@ Type: Informational
 
 The purpose of this RFC is to clarify which platforms the Chef community chooses to work on, and how those platforms are maintained.
 
-The [chef docs site](https://docs.chef.io/) has [details of the platforms Chef Software, Inc validates for release](https://docs.chef.io/platforms.html).
+The [chef docs site](https://docs.chef.io/) has [details of the platforms Chef Software, Inc. supports commercially](https://docs.chef.io/platforms.html).
 
-# Types of Support
+# Commercial vs. Community Support
 
-This RFC outlines the process for community support of a platforms on Chef, but it's worth noting the distinction between community supported and Chef Software Inc. supported:
-
-- Commercial Support consists of the platforms that are supported as part of a paid commercial support contract with Chef Software Inc. For a complete list of commercially supported platforms see the [Chef Platform Support Docs ](https://docs.chef.io/platforms.html).
-- Community Support is made up of platforms for which support is only available through the Chef community on a best effort basis.
+This RFC is concerned with platforms maintained by the community within Chef OSS projects. These additional platforms are not supported by Chef Software Inc. commercially, and are maintained on a best effort basis by community members.
 
 # Adding a new platform
 
-Community maintenance of a platform requires that core chef resources,
-including `package`, `file`, and `service`, MUST have working providers
-for the platform. For example, on Debian the package provider supports both
-`dpkg` and `apt`. Ohai MUST also be able to gather relevant information on
-the platform such as platform information, cpu type/count, and available memory.
+Community maintenance of a platform requires that core chef resources, including `package`, `file`, and `service`, MUST have working providers for the platform. For example, on Debian the package provider supports both `dpkg` and `apt`. Ohai MUST also be able to gather relevant information on the platform such as platform information, cpu type/count, and available memory.
 
-In addition to support in code, there SHOULD be a Lieutenant for the
-platform, per RFC 30. There MAY also be one or more Maintainers for the
-platform. The Lieutenant and any Maintainers are responsible for
-reviewing RFCs and code that affects the platform, and SHOULD be
-responsible for ensuring that new versions of the platform are
-supported.
+In addition to support in code, there SHOULD be a Lieutenant for the platform, per RFC 30. There MAY also be one or more Maintainers for the platform. The Lieutenant and any Maintainers are responsible for reviewing RFCs and code that affects the platform, and SHOULD be responsible for ensuring that new versions of the platform are supported.
 
 # Currently supported platforms
 
 Platform | Architectures | Package Format
  ---- | --- | ---
- AIX  | ppc64 | bff
  Arch Linux | x86_64 | pacman
- CentOS | i386, x86_64 | rpm
- Debian | i386, x86_64 | deb
  Fedora  | x86_64 | rpm
- FreeBSD  | i386, amd64 | pkg
+ Debian | x86_64 | deb
  Gentoo Linux | x86_64 |
- macOS | x86_64 | dmg
  OmniOS | x86_64 | ips
  OpenSUSE | x86_64 | rpm
- Oracle Enterprise Linux | i386, x86_64 | rpm
- Red Hat Enterprise Linux | x86_64, s390x, ppc64le (7.x), ppc64 (7.x) | rpm
- Scientific Linux | i386, x86_64	| rpm
- Solaris | sparc, x86 | shar
- SUSE Linux Enterprise Server  | x86_64, s390x, ppc64le, ppc64 | rpm
- Ubuntu Linux | x86, x86_64 | deb
- Windows | x86, x86_64 | msi
+ Ubuntu Linux (non-LTS) | x86, x86_64 | deb
 
 # Platform Support EOL Policy
 
@@ -65,18 +43,11 @@ according to those vendors’ terms:
 
 Platform | Vendor End of Life
 ---- | ---
-AIX | IBM End of Support Date
 Debian | End of maintenance updates
-Enterprise Linux (covers RedHat Enterprise Linux, CentOS) | End of Production 3
 Fedora | End of Life
-FreeBSD | End of Life
-Microsoft Windows | End of Extended Support
+OmniOS | End of Support
 openSUSE | End of Life
-Oracle Enterprise Linux | Premier Support Ends
-Oracle Solaris | Premier Support Ends
-SUSE Linux Enterprise Server | General Support Ends
 Ubuntu Linux | End of maintenance updates
-
 
 ## Copyright
 


### PR DESCRIPTION
This document was really important at the time and allowed us to write some nice words on the docs site, but now the docs site is actually better setup and we should update this RFC with some of those words.

- Remove the list of specific versions that we weren't keeping up to date
- Clarify that Ohai needs to work on any new platform
- Clarify the types of support (commercial vs. community)
- Document how we align with vendor support cycles in deciding what platform versions we support