### PR TITLE
opscode.com / getchef.com -> chef.io

### DIFF
--- a/rfc011-resource-guard.md
+++ b/rfc011-resource-guard.md
@@ -24,8 +24,8 @@ Client.
 Specifically, the document specifies the behavior and records the reasoning for the
 `guard_interpreter` and `convert_boolean_return` attributes of Chef resources
 as implemented in
-[Chef 11.12.0](http://www.getchef.com/blog/2014/04/08/release-chef-client-11-12-0-10-32-2/)
-and later versions of the Chef Client. See  <https://docs.opscode.com> for
+[Chef 11.12.0](http://www.chef.io/blog/2014/04/08/release-chef-client-11-12-0-10-32-2/)
+and later versions of the Chef Client. See  <https://docs.chef.io> for
 authoritative, updated documentation on these features.
 
 ## Motivation
@@ -67,7 +67,7 @@ the following use cases:
 
 ## Definitions
 This document assumes familiarity with the Chef resource DSL, which is
-documented at <http://docs.opscode.com/chef/resources.html>.
+documented at <http://docs.chef.io/chef/resources.html>.
 
 These definitions are used throughout the discussion:
 
@@ -242,7 +242,7 @@ end
 ## Guard interpreter formal specification
 
 The documented behavior for guards can be found at
-<http://docs.opscode.com/resource_common.html>. Guards are expressed via the optional
+<http://docs.chef.io/resource_common.html>. Guards are expressed via the optional
 `not_if` and `only_if` attributes -- the expression following the attribute
 may be either a block or a string.
 
@@ -617,8 +617,8 @@ Chef Client.
 
 ## References and further reading
 
-* Chef documentation: <http://docs.opscode.com>
-* Chef resource documentation: <http://docs.opscode.com/resource.html>
-* Chef guard documentation: <http://docs.opscode.com/resource_common.html>.
-* Chef guard_interpreter documentation: <http://docs.opscode.com/resource_common.html>.
-* Chef Client open source project: <https://github.com/chef/chef>. 
+* Chef documentation: <http://docs.chef.io>
+* Chef resource documentation: <http://docs.chef.io/resource.html>
+* Chef guard documentation: <http://docs.chef.io/resource_common.html>.
+* Chef guard_interpreter documentation: <http://docs.chef.io/resource_common.html>.
+* Chef Client open source project: <https://github.com/chef/chef>.

--- a/rfc014-universe-endpoint.md
+++ b/rfc014-universe-endpoint.md
@@ -1,7 +1,7 @@
 ---
 RFC: 14
 Title: Universe Endpoint for Chef Server
-Author: Daniel DeLeo <dan@getchef.com>
+Author: Daniel DeLeo <dan@chef.io>
 Status: Final
 Type: Standards Track
 Tracking:

--- a/rfc015-chef-12.md
+++ b/rfc015-chef-12.md
@@ -17,7 +17,7 @@ First some data for information purposes:
 
 * Currently Chef Client has two major versions that are supported. The latest versions that are soon to be released are 10.34.0 & 11.14.0. Chef 10 has been around since Jun 18 2012 and Chef 11 has been around since Feb 1 2013.
 * All supported versions of Chef Client supports Ruby versions `1.8.7` (End of Lifed on June  2013), `1.9.3-p484` (will End of Life on Feb 23 2015) & `2.1.2`.
-* Based on the release cadence we've established around the time of [11.6.0](http://www.getchef.com/blog/2013/07/23/chef-client-11-6-0-ohai-6-18-0-and-more/) release, Chef Client ships with a minor version bump approximately every 3 months and with a major version bump approximately every year.
+* Based on the release cadence we've established around the time of [11.6.0](http://www.chef.io/blog/2013/07/23/chef-client-11-6-0-ohai-6-18-0-and-more/) release, Chef Client ships with a minor version bump approximately every 3 months and with a major version bump approximately every year.
 
 ## Chef Support Statement
 

--- a/rfc016-homebrew-osx-package-provider.md
+++ b/rfc016-homebrew-osx-package-provider.md
@@ -9,7 +9,7 @@ Title: Make Homebrew OS X's Default Package Provider
 
 # Make Homebrew OS X's Default Package Provider
 
-[Homebrew](http://brew.sh) is a very popular source-compile based package manager for OS X. A [cookbook](https://supermarket.getchef.com/cookbooks/homebrew) providing a homebrew as the OS X default provider for Chef's package resource has existed for years. Currently in Chef, the default package provider on `mac_os_x` platforms is [Macports](http://www.macports.org/). Since the cookbook makes homebrew the default in a `libraries` file, it is automatically loaded and present on any node that has the homebrew cookbook downloaded as a dependency, even if they're not using it. Many users may not even be aware that macports is the Chef default.
+[Homebrew](http://brew.sh) is a very popular source-compile based package manager for OS X. A [cookbook](https://supermarket.chef.io/cookbooks/homebrew) providing a homebrew as the OS X default provider for Chef's package resource has existed for years. Currently in Chef, the default package provider on `mac_os_x` platforms is [Macports](http://www.macports.org/). Since the cookbook makes homebrew the default in a `libraries` file, it is automatically loaded and present on any node that has the homebrew cookbook downloaded as a dependency, even if they're not using it. Many users may not even be aware that macports is the Chef default.
 
 ## Specification
 
@@ -43,9 +43,9 @@ This RFC proposes to change this to:
 }
 ```
 
-It would largely leverage the code in the homebrew cookbook's `homebrew_package.rb` [libraries](https://github.com/opscode-cookbooks/homebrew/blob/master/libraries/homebrew_package.rb). We would probably need to clean some things up and modernize it to better fit with the rest of the Chef core package providers, and we would definitely need to have tests added.
+It would largely leverage the code in the homebrew cookbook's `homebrew_package.rb` [libraries](https://github.com/chef-cookbooks/homebrew/blob/master/libraries/homebrew_package.rb). We would probably need to clean some things up and modernize it to better fit with the rest of the Chef core package providers, and we would definitely need to have tests added.
 
-Macports would still remain in Chef as an alternative for those who use it, and it could be set as default similar to what the homebrew cookbook does now, in its [own cookbook](https://supermarket/getchef.com/cookbooks/macports).
+Macports would still remain in Chef as an alternative for those who use it, and it could be set as default similar to what the homebrew cookbook does now, in its [own cookbook](https://supermarket/chef.io/cookbooks/macports).
 
 ## Motivation
 
@@ -65,8 +65,8 @@ The `homebrew` cookbook maintained by CHEF is the reference implementation. It l
 
 ## Copyright
 
-The code to implement this feature will come directly from CHEF's homebrew cookbook. It was originally written by Graeme Mathieson, and was licensed under the [Apache 2.0 Software License](https://github.com/opscode-cookbooks/homebrew/blob/49936df5fd8cc6610262621b3c41c1e3bcbb9c62/metadata.rb#L3). The current copyrights listed in the cookbook are:
+The code to implement this feature will come directly from CHEF's homebrew cookbook. It was originally written by Graeme Mathieson, and was licensed under the [Apache 2.0 Software License](https://github.com/chef-cookbooks/homebrew/blob/49936df5fd8cc6610262621b3c41c1e3bcbb9c62/metadata.rb#L3). The current copyrights listed in the cookbook are:
 
 - Copyright 2011, Graeme Mathieson <mathie@woss.name>
 - Copyright 2011-2013, Opscode, Inc. <legal@opscode.com>
-- Copyright 2014, Chef Software, Inc <legal@getchef.com>
+- Copyright 2014, Chef Software, Inc <legal@chef.io>

--- a/rfc018-attribute-syntax.md
+++ b/rfc018-attribute-syntax.md
@@ -1,7 +1,7 @@
 ---
 RFC: 18
 Title: Attribute Subkey Syntax
-Author: Steven Danna <steve@getchef.com>
+Author: Steven Danna <steve@chef.io>
 Status: Accepted
 Type: Standards Track
 Chef-Version: 12

--- a/rfc019-chef-workflows.md
+++ b/rfc019-chef-workflows.md
@@ -1,7 +1,7 @@
 ---
 RFC: 19
 Title: The Great Workflow RFC
-Author: Adam Jacob <adam@getchef.com>
+Author: Adam Jacob <adam@chef.io>
 Status: Accepted
 Type: Standards Track
 Chef-Version: 12
@@ -34,7 +34,7 @@ The workflows in this document are "supported" for three reasons:
 
 If you think you have another workflow, that's amazing! The currently supported workflows came about from experimentation just like yours. If it becomes mature enough to have broad ecosystem support, propose a change to this RFC.
 
-All workflows and commands documented in this RFC assume you are using the [Chef Development Kit](http://downloads.getchef.com/chef-dk/).
+All workflows and commands documented in this RFC assume you are using the [Chef Development Kit](http://downloads.chef.io/chef-dk/).
 
 ## Chef DK & Knife
 
@@ -56,9 +56,9 @@ Rather than detail every step here, lets call out a couple of important principl
 
 1. There are no shortcuts to building complex infrastructure - by extension, there are no shortcuts to building complex infrastructure with Chef. You have to learn things, piece by piece. Zooming someone to the end doesn't help - it actually hurts.
 1. The concept of [Progressive Disclosure](http://en.wikipedia.org/wiki/Progressive_disclosure) should always be kept in mind. Make more information available easily, but don't overwhelm users with every feature and possibility.
-1. The [Learn Chef](http://learn.getchef.com) site is the place for collaborating on early
+1. The [Learn Chef](http://learn.chef.io) site is the place for collaborating on early
 stage tutorial content. If a user needs to learn the basics, send them here.
-1. The [Fundamentals Webinar](http://learn.getchef.com/additional-resources/) is a series of video tutorials and attendant slide decks that can augment the Learn Chef content.
+1. The [Fundamentals Webinar](http://learn.chef.io/additional-resources/) is a series of video tutorials and attendant slide decks that can augment the Learn Chef content.
 
 Regardless of the workflow you eventually settle in to, these rules and basics apply across the board.
 
@@ -123,7 +123,7 @@ $ git commit -a -m "Super dope policy"
 
 ### How to manage external dependencies
 
-In this workflow, all external dependencies are tracked within the same source code repository as your custom-built source code. To install, for example, a 3rd party cookbook called "apache2" from the [supermarket](http://supermarket.getchef.com):
+In this workflow, all external dependencies are tracked within the same source code repository as your custom-built source code. To install, for example, a 3rd party cookbook called "apache2" from the [supermarket](http://supermarket.chef.io):
 
 ```
 $ chef vendor dependencies

--- a/rfc022-arbitrary-cookbook-identifiers.md
+++ b/rfc022-arbitrary-cookbook-identifiers.md
@@ -1,7 +1,7 @@
 ---
 RFC: 22
 Title: Arbitrary Cookbook Identifiers
-Author: Daniel DeLeo <ddeleo@getchef.com>
+Author: Daniel DeLeo <ddeleo@chef.io>
 Status: Accepted
 Type: Standards Track
 Chef-Version: 12
@@ -74,7 +74,7 @@ look like:
     "identifier": "886757f9ae3cf2520c82b791195c27ecafd93656",
     "version": "1.10.4",
     "url": "https://chef.example.org/organizations/:org/cookbook_artifacts/apache2/886757f9ae3cf2520c82b791195c27ecafd93656",
-    "origin_url": "https://supermarket.getchef.com/cookbooks/apache2/versions/1.10.4/download",
+    "origin_url": "https://supermarket.chef.io/cookbooks/apache2/versions/1.10.4/download",
     "origin_id": "1.10.4"
   }
 ```

--- a/rfc024-local-mode-default.md
+++ b/rfc024-local-mode-default.md
@@ -1,7 +1,7 @@
 ---
 RFC: 24
 Title: Local Mode Default
-Author: John Keiser <jkeiser@getchef.com>
+Author: John Keiser <jkeiser@chef.io>
 Status: Withdrawn
 Type: Standards Track
 Chef-Version: 12

--- a/rfc025-multitenant-chef-client-support.md
+++ b/rfc025-multitenant-chef-client-support.md
@@ -1,7 +1,7 @@
 ---
 RFC: 25
 Title: Multitenant Chef Client Support
-Author: John Keiser <jkeiser@getchef.com>
+Author: John Keiser <jkeiser@chef.io>
 Status: Accepted
 Type: Standards Track
 Chef-Version: 12

--- a/rfc026-remove-http-config-files.md
+++ b/rfc026-remove-http-config-files.md
@@ -1,7 +1,7 @@
 ---
 RFC: 26
 Title: Remove HTTP Config Files
-Author: John Keiser <jkeiser@getchef.com>
+Author: John Keiser <jkeiser@chef.io>
 Status: Final
 Type: Standards Track
 Chef-Version: 12

--- a/rfc027-file-content-verification.md
+++ b/rfc027-file-content-verification.md
@@ -1,7 +1,7 @@
 ---
 RFC: 27
 Title: File Content Verification
-Author: Steven Danna <steve@getchef.com>
+Author: Steven Danna <steve@chef.io>
 Status: Final
 Type: Standards Track
 Chef-Version: 12

--- a/rfc029-governance-policy.md
+++ b/rfc029-governance-policy.md
@@ -1,7 +1,7 @@
 ---
 RFC: 29
 Title: Chef Board of Governance
-Author: Adam Jacob <adam@getchef.com>
+Author: Adam Jacob <adam@chef.io>
 Status: Removed
 Type: Process
 ---

--- a/rfc031-replace-solo-with-local-mode.md
+++ b/rfc031-replace-solo-with-local-mode.md
@@ -1,7 +1,7 @@
 ---
 RFC: 31
 Title: Replace chef-solo with chef-client local mode
-Author: Joshua Timberman <joshua@getchef.com>
+Author: Joshua Timberman <joshua@chef.io>
 Status: Accepted
 Type: Standards Track
 ---

--- a/rfc034-ruby-193-eol.md
+++ b/rfc034-ruby-193-eol.md
@@ -1,7 +1,7 @@
 ---
 RFC: 34
 Title: Ruby Version Deprecation Policy
-Author: Daniel DeLeo <dan@getchef.com>
+Author: Daniel DeLeo <dan@chef.io>
 Status: Accepted
 Type: Standards Track
 ---

--- a/rfc035-audit-mode.md
+++ b/rfc035-audit-mode.md
@@ -1,7 +1,7 @@
 ---
 RFC: 35
 Title: Audit-Mode for Chef Client
-Author: Claire McQuin <claire@getchef.com>
+Author: Claire McQuin <claire@chef.io>
 Status: Accepted
 Type: Standards Track
 ---

--- a/rfc049-track-rfcs.md
+++ b/rfc049-track-rfcs.md
@@ -33,7 +33,7 @@ For example, metadata might look like this:
 ```yaml
 ---
 RFC: XXX
-Author: Daniel DeLeo <dan@getchef.com>
+Author: Daniel DeLeo <dan@chef.io>
 Status: Final
 Type: Standards Track
 Chef-Version: 12.0


### PR DESCRIPTION
Cleanup old links to point to chef.io

Signed-off-by: Tim Smith <tsmith@chef.io>